### PR TITLE
Preserve font collection face selection and cell metrics

### DIFF
--- a/font.cpp
+++ b/font.cpp
@@ -7,6 +7,7 @@
 #include "font.h"
 
 #include "composer.h"
+#include "font_resolver.h"
 #include "grapheme.h"
 #include "options.h"
 #include "utf8.h"
@@ -33,10 +34,11 @@ using namespace stl;
 
 namespace {
     struct FontImpl final: public Font {
-        FontImpl(StringView filename, FontKind kind, FontMetrics& metrics);
+        FontImpl(const FontFace& font, FontKind kind, FontMetrics& metrics);
         ~FontImpl() noexcept;
 
         FontGlyph glyph(const u32* codepoints, size_t count) override;
+        long faceIndex() const override;
 
         void configure();
         void configureFixed();
@@ -85,7 +87,7 @@ namespace {
     }
 }
 
-FontImpl::FontImpl(StringView filename, FontKind kind, FontMetrics& metrics)
+FontImpl::FontImpl(const FontFace& font, FontKind kind, FontMetrics& metrics)
     : kind_(kind)
     , metrics_(metrics)
 {
@@ -93,10 +95,10 @@ FontImpl::FontImpl(StringView filename, FontKind kind, FontMetrics& metrics)
         fail(StringView(u8"could not initialize FreeType"));
     }
 
-    Buffer filenameBuffer(filename);
-    if (FT_New_Face(library_, filenameBuffer.cStr(), 0, &face_)) {
+    Buffer filenameBuffer(font.filename);
+    if (FT_New_Face(library_, filenameBuffer.cStr(), font.index, &face_)) {
         close();
-        fail(StringBuilder() << StringView(u8"failed to open font ") << filename);
+        fail(StringBuilder() << StringView(u8"failed to open font ") << font.filename);
     }
 
     try {
@@ -181,16 +183,32 @@ void FontImpl::configureFixed() {
     }
 
     const FT_Bitmap_Size& size = face_->available_sizes[bestIndex];
-    if (kind_ == FontKind::Primary) {
-        const int pixels = size.y_ppem > 0 ? maximum(1, rounded(size.y_ppem / 64.0)) : size.height;
-        const double scale = hasColor_ ? opts.fontsize / (double)(pixels) : 1;
-        metrics_.width = rounded(size.width * scale);
-        metrics_.height = rounded(size.height * scale);
-        metrics_.baseline = 0;
-    } else if (!hasColor_ && (metrics_.width != size.width || metrics_.height != size.height)) {
-        fail(StringBuilder() << StringView(u8"font cell mismatch: expected ") << metrics_.width << StringView(u8"x") << metrics_.height << StringView(u8", got ") << size.width << StringView(u8"x") << size.height);
+    const int strikePixels = size.y_ppem > 0 ? maximum(1, rounded(size.y_ppem / 64.0)) : size.height;
+    const double scale = hasColor_ ? opts.fontsize / (double)(strikePixels) : 1;
+    FontMetrics actual{
+        .width = hasColor_ ? rounded(size.width * scale) : (u16)(size.width),
+        .height = hasColor_ ? rounded(size.height * scale) : (u16)(size.height),
+        .baseline = 0,
+    };
+    if (!hasColor_ && face_->size != nullptr) {
+        actual.baseline = rounded(face_->size->metrics.ascender / 64.0);
     }
-    if (kind_ != FontKind::Overlay && face_->height != 0) {
+    if (kind_ == FontKind::Primary) {
+        metrics_ = actual;
+    } else if (kind_ == FontKind::DoubleWidth && !hasColor_) {
+        if (metrics_.width != actual.width || metrics_.height != actual.height) {
+            fail(StringBuilder() << StringView(u8"font cell mismatch: expected ") << metrics_.width << StringView(u8"x") << metrics_.height << StringView(u8", got ") << actual.width << StringView(u8"x") << actual.height);
+        }
+        metrics_.baseline = actual.baseline;
+    } else if (kind_ == FontKind::Overlay && !hasColor_) {
+        if (metrics_.height != actual.height) {
+            fail(StringBuilder() << StringView(u8"font cell mismatch: expected ") << metrics_.width << StringView(u8"x") << metrics_.height << StringView(u8", got ") << actual.width << StringView(u8"x") << actual.height);
+        }
+        if (metrics_.baseline != actual.baseline) {
+            fail(StringBuilder() << StringView(u8"font baseline mismatch: expected ") << metrics_.baseline << StringView(u8", got ") << actual.baseline);
+        }
+    }
+    if (hasColor_ && kind_ != FontKind::Overlay && face_->height != 0) {
         metrics_.baseline = rounded(metrics_.height * (double)(face_->ascender) / face_->height);
     }
 }
@@ -199,18 +217,36 @@ void FontImpl::configureScaled() {
     if (FT_Set_Pixel_Sizes(face_, opts.fontsize, opts.fontsize)) {
         fail(StringView(u8"could not select scalable font size"));
     }
-    if (face_->units_per_EM == 0 || face_->max_advance_width == 0 || face_->height == 0) {
+    if (face_->units_per_EM == 0 || face_->height == 0) {
         fail(StringView(u8"font has unusable scalable metrics"));
     }
 
-    const double width = opts.fontsize * (double)(face_->max_advance_width) / face_->units_per_EM;
-    const double height = width * face_->height / face_->max_advance_width + 1;
+    double width = metrics_.width;
+    if (kind_ != FontKind::Overlay) {
+        const FT_ULong widthCodepoint = kind_ == FontKind::DoubleWidth ? 0x3000 : 'M';
+        const bool hasRepresentativeAdvance =
+            FT_Get_Char_Index(face_, widthCodepoint) != 0 &&
+            FT_Load_Char(face_, widthCodepoint, FT_LOAD_DEFAULT) == 0 &&
+            face_->glyph->advance.x > 0;
+        if (hasRepresentativeAdvance) {
+            width = face_->glyph->advance.x / 64.0;
+        } else {
+            if (face_->max_advance_width <= 0) {
+                fail(StringView(u8"font has unusable scalable width metrics"));
+            }
+            width = opts.fontsize * (double)(face_->max_advance_width) / face_->units_per_EM;
+        }
+    }
+    const double height = opts.fontsize * (double)(face_->height) / face_->units_per_EM + 1;
     const FontMetrics actual{
-        .width = rounded(width),
+        .width = kind_ == FontKind::Overlay ? metrics_.width : rounded(width),
         .height = rounded(height),
         .baseline = rounded(height * face_->ascender / face_->height),
     };
-    if (kind_ != FontKind::Primary && !hasColor_ && (metrics_.width != actual.width || metrics_.height != actual.height)) {
+    if (kind_ == FontKind::DoubleWidth && !hasColor_ && (metrics_.width != actual.width || metrics_.height != actual.height)) {
+        fail(StringBuilder() << StringView(u8"font cell mismatch: expected ") << metrics_.width << StringView(u8"x") << metrics_.height << StringView(u8", got ") << actual.width << StringView(u8"x") << actual.height);
+    }
+    if (kind_ == FontKind::Overlay && !hasColor_ && metrics_.height != actual.height) {
         fail(StringBuilder() << StringView(u8"font cell mismatch: expected ") << metrics_.width << StringView(u8"x") << metrics_.height << StringView(u8", got ") << actual.width << StringView(u8"x") << actual.height);
     }
     if (kind_ == FontKind::Overlay && metrics_.baseline != actual.baseline) {
@@ -474,6 +510,10 @@ FontGlyph FontImpl::glyph(const u32* codepoints, size_t count) {
     };
 }
 
-Font* Font::create(Composer& composer, StringView filename, FontKind kind, FontMetrics& metrics) {
-    return composer.pool->make<FontImpl>(filename, kind, metrics);
+long FontImpl::faceIndex() const {
+    return face_->face_index;
+}
+
+Font* Font::create(Composer& composer, const FontFace& face, FontKind kind, FontMetrics& metrics) {
+    return composer.pool->make<FontImpl>(face, kind, metrics);
 }

--- a/font.h
+++ b/font.h
@@ -13,6 +13,7 @@ namespace stl {
 }
 
 struct Composer;
+struct FontFace;
 
 struct FontGlyph {
     const void* data = nullptr;
@@ -37,6 +38,7 @@ struct FontMetrics {
 // bitmap remains valid until the next glyph() call on the same Font.
 struct Font {
     virtual FontGlyph glyph(const u32* codepoints, size_t count) = 0;
+    virtual long faceIndex() const = 0;
 
-    static Font* create(Composer& composer, stl::StringView filename, FontKind kind, FontMetrics& metrics);
+    static Font* create(Composer& composer, const FontFace& face, FontKind kind, FontMetrics& metrics);
 };

--- a/font_pack.cpp
+++ b/font_pack.cpp
@@ -30,9 +30,11 @@ namespace {
         bool hasItalic() const override;
         bool hasBoldItalic() const override;
         bool hasDoubleWidth() const override;
+        long regularFaceIndex() const override;
+        long doubleWidthFaceIndex() const override;
         FontGlyph glyph(const u32* codepoints, size_t count, FontStyle style, bool doubleWidth) override;
 
-        Font* createOptional(Composer& composer, StringView filename, FontKind kind, FontMetrics metrics);
+        Font* createOptional(Composer& composer, const FontFace& face, FontKind kind, FontMetrics metrics);
         Font* select(FontStyle style) const noexcept;
         FontGlyph fallback(Font* font, Font* base, const u32* codepoints, size_t count);
 
@@ -67,12 +69,12 @@ FontpackImpl::FontpackImpl(Composer& composer, StringView fontname, StringView d
     }
 }
 
-Font* FontpackImpl::createOptional(Composer& composer, StringView filename, FontKind kind, FontMetrics metrics) {
-    if (filename.empty()) {
+Font* FontpackImpl::createOptional(Composer& composer, const FontFace& face, FontKind kind, FontMetrics metrics) {
+    if (face.empty()) {
         return nullptr;
     }
     try {
-        return Font::create(composer, filename, kind, metrics);
+        return Font::create(composer, face, kind, metrics);
     } catch (Exception&) {
         return nullptr;
     }
@@ -100,6 +102,14 @@ bool FontpackImpl::hasBoldItalic() const {
 
 bool FontpackImpl::hasDoubleWidth() const {
     return doubleWidth_ != nullptr;
+}
+
+long FontpackImpl::regularFaceIndex() const {
+    return regular_->faceIndex();
+}
+
+long FontpackImpl::doubleWidthFaceIndex() const {
+    return doubleWidth_ == nullptr ? 0 : doubleWidth_->faceIndex();
 }
 
 Font* FontpackImpl::select(FontStyle style) const noexcept {

--- a/font_pack.h
+++ b/font_pack.h
@@ -28,6 +28,8 @@ struct Fontpack {
     virtual bool hasItalic() const = 0;
     virtual bool hasBoldItalic() const = 0;
     virtual bool hasDoubleWidth() const = 0;
+    virtual long regularFaceIndex() const = 0;
+    virtual long doubleWidthFaceIndex() const = 0;
 
     virtual FontGlyph glyph(const u32* codepoints, size_t count, FontStyle style, bool doubleWidth) = 0;
 

--- a/font_resolver.cpp
+++ b/font_resolver.cpp
@@ -45,7 +45,7 @@ namespace {
         }
     }
 
-    StringView fontconfigFile(ObjPool* pool, StringView family, int weight, int slant) {
+    FontFace fontconfigFace(ObjPool* pool, StringView family, int weight, int slant) {
         if (!initializeFontconfig()) {
             return {};
         }
@@ -73,37 +73,38 @@ namespace {
         }
 
         FcChar8* file = nullptr;
-        StringView path;
+        FontFace face;
         if (FcPatternGetString(match, FC_FILE, 0, &file) == FcResultMatch) {
-            path = pool->intern(StringView((const char*)(file)));
+            face.filename = pool->intern(StringView((const char*)(file)));
+            FcPatternGetInteger(match, FC_INDEX, 0, &face.index);
         }
         FcPatternDestroy(match);
-        return path;
+        return face;
     }
 }
 
 FontVariants resolveFontconfig(ObjPool* pool, StringView family) {
     FontVariants variants;
     if (family.memChr('/')) {
-        variants.regular = pool->intern(family);
+        variants.regular.filename = pool->intern(family);
         return variants;
     }
-    variants.regular = fontconfigFile(pool, family, FC_WEIGHT_REGULAR, FC_SLANT_ROMAN);
+    variants.regular = fontconfigFace(pool, family, FC_WEIGHT_REGULAR, FC_SLANT_ROMAN);
     if (variants.regular.empty()) {
         return variants;
     }
 
-    StringView path = fontconfigFile(pool, family, FC_WEIGHT_BOLD, FC_SLANT_ROMAN);
-    if (!path.empty() && path != variants.regular) {
-        variants.bold = path;
+    FontFace face = fontconfigFace(pool, family, FC_WEIGHT_BOLD, FC_SLANT_ROMAN);
+    if (!face.empty() && face != variants.regular) {
+        variants.bold = face;
     }
-    path = fontconfigFile(pool, family, FC_WEIGHT_REGULAR, FC_SLANT_ITALIC);
-    if (!path.empty() && path != variants.regular) {
-        variants.italic = path;
+    face = fontconfigFace(pool, family, FC_WEIGHT_REGULAR, FC_SLANT_ITALIC);
+    if (!face.empty() && face != variants.regular) {
+        variants.italic = face;
     }
-    path = fontconfigFile(pool, family, FC_WEIGHT_BOLD, FC_SLANT_ITALIC);
-    if (!path.empty() && path != variants.regular && path != variants.bold && path != variants.italic) {
-        variants.boldItalic = path;
+    face = fontconfigFace(pool, family, FC_WEIGHT_BOLD, FC_SLANT_ITALIC);
+    if (!face.empty() && face != variants.regular && face != variants.bold && face != variants.italic) {
+        variants.boldItalic = face;
     }
     return variants;
 }

--- a/font_resolver.h
+++ b/font_resolver.h
@@ -12,11 +12,28 @@ namespace stl {
     class ObjPool;
 }
 
+struct FontFace {
+    stl::StringView filename;
+    int index = 0;
+
+    bool empty() const {
+        return filename.empty();
+    }
+
+    bool operator==(const FontFace& other) const {
+        return filename == other.filename && index == other.index;
+    }
+
+    bool operator!=(const FontFace& other) const {
+        return !(*this == other);
+    }
+};
+
 struct FontVariants {
-    stl::StringView regular;
-    stl::StringView bold;
-    stl::StringView italic;
-    stl::StringView boldItalic;
+    FontFace regular;
+    FontFace bold;
+    FontFace italic;
+    FontFace boldItalic;
 };
 
 FontVariants resolveFontconfig(stl::ObjPool* pool, stl::StringView fontname);

--- a/test_mode.cpp
+++ b/test_mode.cpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <deque>
@@ -57,12 +58,75 @@
 #include <unistd.h>
 #include <vector>
 
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
 namespace stl {}
 
 using namespace stl;
 
 namespace {
     extern "C" int openpty(int*, int*, char*, const termios*, const winsize*);
+
+    struct TestFaceMetrics {
+        bool valid = false;
+        long faceIndex = 0;
+        bool hasGlyph = false;
+        u16 advance = 0;
+        u16 maxAdvance = 0;
+        u16 height = 0;
+        u16 baseline = 0;
+    };
+
+    TestFaceMetrics inspectFace(const FontFace& font, FT_ULong codepoint) {
+        FT_Library library = nullptr;
+        FT_Face face = nullptr;
+        TestFaceMetrics metrics;
+
+        if (FT_Init_FreeType(&library)) {
+            return metrics;
+        }
+        Buffer filenameBuffer(font.filename);
+        if (FT_New_Face(library, filenameBuffer.cStr(), font.index, &face)) {
+            FT_Done_FreeType(library);
+            return metrics;
+        }
+
+        metrics.faceIndex = face->face_index;
+        if (face->num_fixed_sizes == 0 && face->units_per_EM > 0 && face->height != 0 &&
+            FT_Set_Pixel_Sizes(face, opts.fontsize, opts.fontsize) == 0) {
+            const double height = opts.fontsize * (double)(face->height) / face->units_per_EM + 1;
+            metrics.valid = true;
+            metrics.maxAdvance = (u16)(std::lround(opts.fontsize * (double)(face->max_advance_width) / face->units_per_EM));
+            metrics.height = (u16)(std::lround(height));
+            metrics.baseline = (u16)(std::lround(height * face->ascender / face->height));
+            metrics.hasGlyph = FT_Get_Char_Index(face, codepoint) != 0 &&
+                               FT_Load_Char(face, codepoint, FT_LOAD_DEFAULT) == 0 &&
+                               face->glyph->advance.x > 0;
+            if (metrics.hasGlyph) {
+                metrics.advance = (u16)(std::lround(face->glyph->advance.x / 64.0));
+            }
+        }
+
+        FT_Done_Face(face);
+        FT_Done_FreeType(library);
+        return metrics;
+    }
+
+    std::vector<std::string> splitFields(const std::string& request) {
+        std::vector<std::string> fields;
+        size_t offset = 0;
+        while (offset <= request.size()) {
+            const size_t separator = request.find('\0', offset);
+            if (separator == std::string::npos) {
+                fields.push_back(request.substr(offset));
+                break;
+            }
+            fields.push_back(request.substr(offset, separator - offset));
+            offset = separator + 1;
+        }
+        return fields;
+    }
 
     struct TestPty final: public Pty, public Listener {
         TestPty(Composer& composer, int fd);
@@ -1380,15 +1444,86 @@ int runTestMode(Composer& composer, TestModeInput& input, int controlFd, int arg
                 ObjPool::Ref fontPool = ObjPool::fromMemory();
                 const FontVariants variants = resolveFontconfig(fontPool.mutPtr(), StringView((const u8*)(family.data()), family.size()));
                 std::string encoded;
-                const StringView paths[] = {variants.regular, variants.bold, variants.italic, variants.boldItalic};
-                for (size_t index = 0; index < std::size(paths); ++index) {
+                const FontFace faces[] = {variants.regular, variants.bold, variants.italic, variants.boldItalic};
+                for (size_t index = 0; index < std::size(faces); ++index) {
                     if (index != 0) {
                         encoded.push_back('\0');
                     }
-                    const StringView path = paths[index];
-                    encoded.append((const char*)(path.data()), path.length());
+                    const FontFace& face = faces[index];
+                    encoded.append((const char*)(face.filename.data()), face.filename.length());
+                    encoded.push_back('\0');
+                    encoded += std::to_string(face.index);
                 }
                 writeAll(controlFd, "OK " + encodeHex(encoded) + "\n");
+            } else if (line.compare(0, 18, "FONT_FACE_METRICS ") == 0) {
+                const std::vector<std::string> fields = splitFields(decodeHex(line.substr(18)));
+                if (fields.size() != 3) {
+                    throw std::runtime_error("invalid font face metrics request");
+                }
+                const FontFace font{
+                    StringView((const u8*)(fields[0].data()), fields[0].size()),
+                    std::stoi(fields[1]),
+                };
+                const FT_ULong codepoint = std::stoul(fields[2]);
+                const TestFaceMetrics metrics = inspectFace(font, codepoint);
+                writeAll(controlFd, "OK " + std::to_string(metrics.valid) + " " + std::to_string(metrics.faceIndex) + " " + std::to_string(metrics.hasGlyph) + " " + std::to_string(metrics.advance) + " " + std::to_string(metrics.maxAdvance) + " " + std::to_string(metrics.height) + " " + std::to_string(metrics.baseline) + "\n");
+            } else if (line.compare(0, 19, "FONT_GLYPH_METRICS ") == 0) {
+                const std::vector<std::string> fields = splitFields(decodeHex(line.substr(19)));
+                if (fields.size() != 3) {
+                    throw std::runtime_error("invalid font glyph metrics request");
+                }
+                const FontFace font{
+                    StringView((const u8*)(fields[0].data()), fields[0].size()),
+                    std::stoi(fields[1]),
+                };
+                const u32 codepoint = std::stoul(fields[2]);
+                ObjPool::Ref fontPool = ObjPool::fromMemory();
+                Composer fontComposer(fontPool.mutPtr());
+                FontMetrics metrics;
+                Font* loaded = Font::create(fontComposer, font, FontKind::Primary, metrics);
+                const FontGlyph glyph = loaded->glyph(&codepoint, 1);
+                size_t nonzero = 0;
+                int firstRow = -1;
+                int lastRow = -1;
+                if (glyph.data != nullptr && !glyph.color) {
+                    const auto* pixels = (const u8*)(glyph.data);
+                    for (size_t offset = 0; offset < glyph.len; ++offset) {
+                        if (pixels[offset] == 0) {
+                            continue;
+                        }
+                        const int row = offset / metrics.width;
+                        ++nonzero;
+                        if (firstRow < 0) {
+                            firstRow = row;
+                        }
+                        lastRow = row;
+                    }
+                }
+                writeAll(controlFd, "OK " + std::to_string(metrics.width) + " " + std::to_string(metrics.height) + " " + std::to_string(metrics.baseline) + " " + std::to_string(glyph.color) + " " + std::to_string(glyph.len) + " " + std::to_string(nonzero) + " " + std::to_string(firstRow) + " " + std::to_string(lastRow) + "\n");
+            } else if (line.compare(0, 13, "FONT_OVERLAY ") == 0) {
+                const std::vector<std::string> fields = splitFields(decodeHex(line.substr(13)));
+                if (fields.size() != 4) {
+                    throw std::runtime_error("invalid font overlay request");
+                }
+                const FontFace primary{
+                    StringView((const u8*)(fields[0].data()), fields[0].size()),
+                    std::stoi(fields[1]),
+                };
+                const FontFace overlay{
+                    StringView((const u8*)(fields[2].data()), fields[2].size()),
+                    std::stoi(fields[3]),
+                };
+                bool compatible = false;
+                ObjPool::Ref fontPool = ObjPool::fromMemory();
+                Composer fontComposer(fontPool.mutPtr());
+                FontMetrics metrics;
+                try {
+                    Font::create(fontComposer, primary, FontKind::Primary, metrics);
+                    Font::create(fontComposer, overlay, FontKind::Overlay, metrics);
+                    compatible = true;
+                } catch (Exception&) {
+                }
+                writeAll(controlFd, "OK " + std::to_string(compatible) + " " + std::to_string(metrics.width) + " " + std::to_string(metrics.height) + " " + std::to_string(metrics.baseline) + "\n");
             } else if (line.compare(0, 10, "FONT_LOAD ") == 0) {
                 const std::string request = decodeHex(line.substr(10));
                 const size_t first = request.find('\0');
@@ -1400,7 +1535,7 @@ int runTestMode(Composer& composer, TestModeInput& input, int controlFd, int arg
                 const StringView fontname((const u8*)(request.data()), first);
                 const StringView dwfontname((const u8*)(request.data() + first + 1), request.size() - first - 1);
                 Fontpack* fonts = Fontpack::create(fontComposer, fontname, dwfontname);
-                writeAll(controlFd, "OK " + std::to_string(fonts->getPx()) + " " + std::to_string(fonts->getPy()) + " " + std::to_string(fonts->hasBold()) + " " + std::to_string(fonts->hasItalic()) + " " + std::to_string(fonts->hasBoldItalic()) + " " + std::to_string(fonts->hasDoubleWidth()) + "\n");
+                writeAll(controlFd, "OK " + std::to_string(fonts->getPx()) + " " + std::to_string(fonts->getPy()) + " " + std::to_string(fonts->hasBold()) + " " + std::to_string(fonts->hasItalic()) + " " + std::to_string(fonts->hasBoldItalic()) + " " + std::to_string(fonts->hasDoubleWidth()) + " " + std::to_string(fonts->regularFaceIndex()) + " " + std::to_string(fonts->doubleWidthFaceIndex()) + "\n");
             } else if (line.compare(0, 13, "RENDER_IMAGE ") == 0) {
                 const std::string request = decodeHex(line.substr(13));
                 const size_t first = request.find('\0');

--- a/tests/COVERAGE.md
+++ b/tests/COVERAGE.md
@@ -48,10 +48,18 @@ Covered now:
 - real child PTY startup with `TERM`, `SHITTY_VERSION`, initial winsize and
   resize-driven winsize update plus `SIGWINCH` delivery;
 - fontconfig family and generic-alias resolution to existing files, followed
-  by successful real FreeType loading and nonzero glyph metrics;
+  by successful real FreeType loading and nonzero glyph metrics, including
+  preservation of collection face indices through FreeType;
+- representative single-width and double-width advances for collection faces
+  instead of unrelated maximum-advance metrics;
 - real four-face fontconfig regular/bold/italic/bold-italic overlay loading;
-- rejection of scalable overlay faces whose width, height or baseline metrics
-  do not match the primary font;
+- scalable overlays retaining primary cell width despite distinct width
+  metrics, while rejecting height or baseline mismatches;
+- fixed-size overlays retaining primary cell width while matching strike height
+  and baseline;
+- multi-codepoint HarfBuzz shaping and intrinsic-color glyph rendering,
+  including a nonzero-index collection primary with a color ZWJ fallback and
+  fixed color-face mask placement at the legacy zero baseline;
 - missing/incompatible double-width font fallback while retaining a usable
   primary font and its metrics;
 - removal of the legacy `-fontpath` option so fontconfig is the only resolver;

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -230,20 +230,90 @@ class Shitty:
         encoded = self._read_hex_response(
             "FONTCONFIG_RESOLVE " + os.fsencode(family).hex()
         ).split(b"\0")
+        if len(encoded) != 8:
+            raise RuntimeError("invalid fontconfig response")
+        result = {}
+        for offset, name in enumerate(
+            ("regular", "bold", "italic", "bold_italic")
+        ):
+            result[name] = os.fsdecode(encoded[2 * offset])
+            result[name + "_index"] = int(encoded[2 * offset + 1])
+        return result
+
+    def font_face_metrics(self, filename, index, codepoint):
+        request = b"\0".join(
+            (
+                os.fsencode(filename),
+                str(index).encode(),
+                str(codepoint).encode(),
+            )
+        )
+        self.stream.write(
+            b"FONT_FACE_METRICS " + request.hex().encode() + b"\n"
+        )
+        response = self._readline().split()
+        if len(response) != 8 or response[0] != "OK":
+            raise RuntimeError("invalid font face metrics response")
         return dict(zip(
-            ("regular", "bold", "italic", "bold_italic"),
-            (os.fsdecode(value) for value in encoded),
+            (
+                "valid", "face_index", "has_glyph", "advance",
+                "max_advance", "py", "baseline",
+            ),
+            map(int, response[1:]),
         ))
+
+    def font_glyph_metrics(self, filename, index, codepoint):
+        request = b"\0".join(
+            (
+                os.fsencode(filename),
+                str(index).encode(),
+                str(codepoint).encode(),
+            )
+        )
+        self.stream.write(
+            b"FONT_GLYPH_METRICS " + request.hex().encode() + b"\n"
+        )
+        response = self._readline().split()
+        if len(response) != 9 or response[0] != "OK":
+            raise RuntimeError("invalid font glyph metrics response")
+        return dict(zip(
+            (
+                "px", "py", "baseline", "color", "length", "nonzero",
+                "first_row", "last_row",
+            ),
+            map(int, response[1:]),
+        ))
+
+    def load_overlay(
+        self, primary_filename, primary_index, overlay_filename, overlay_index
+    ):
+        request = b"\0".join(
+            (
+                os.fsencode(primary_filename),
+                str(primary_index).encode(),
+                os.fsencode(overlay_filename),
+                str(overlay_index).encode(),
+            )
+        )
+        self.stream.write(b"FONT_OVERLAY " + request.hex().encode() + b"\n")
+        response = self._readline().split()
+        if len(response) != 5 or response[0] != "OK":
+            raise RuntimeError("invalid font overlay response")
+        values = tuple(map(int, response[1:]))
+        return dict(zip(("compatible", "px", "py", "baseline"), values))
 
     def load_font(self, family, double_width):
         request = b"\0".join(map(os.fsencode, (family, double_width)))
         self.stream.write(b"FONT_LOAD " + request.hex().encode() + b"\n")
         response = self._readline().split()
-        if len(response) != 7 or response[0] != "OK":
+        if len(response) != 9 or response[0] != "OK":
             raise RuntimeError("invalid font load response")
         values = tuple(map(int, response[1:]))
         return dict(zip(
-            ("px", "py", "bold", "italic", "bold_italic", "double_width"),
+            (
+                "px", "py", "bold", "italic", "bold_italic", "double_width",
+                "regular_face_index", "double_width_face_index",
+            ),
             values,
         ))
 

--- a/tests/test_color_font_render.py
+++ b/tests/test_color_font_render.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 
 from harness import Shitty
+from test_font_resolver import loadable_indexed_fontconfig_matches
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -14,6 +15,24 @@ COLOR_FONT = ROOT / "tests" / "fonts" / "NotoColorEmoji.ttf"
 
 
 class ColorFontRenderTest(unittest.TestCase):
+    def test_fixed_color_mask_preserves_zero_baseline(self):
+        with Shitty(extra_arguments=("-fontsize", "32")) as terminal:
+            glyph = terminal.font_glyph_metrics(COLOR_FONT, 0, 0)
+
+        self.assertEqual(
+            (
+                glyph["px"],
+                glyph["py"],
+                glyph["baseline"],
+                glyph["color"],
+                glyph["length"],
+                glyph["nonzero"],
+                glyph["first_row"],
+                glyph["last_row"],
+            ),
+            (40, 38, 0, 0, 40 * 38, 0, -1, -1),
+        )
+
     def test_color_zwj_grapheme_renders_to_image(self):
         with Shitty(
             columns=2,
@@ -30,6 +49,71 @@ class ColorFontRenderTest(unittest.TestCase):
         self.assertEqual(
             hashlib.sha256(pixels).hexdigest(),
             "9a0ea45ef565bc6fca3da680d205b275bc2a8d3d97bce5c7088c9733df514337",
+        )
+        chromatic_colors = {
+            pixels[offset : offset + 3]
+            for offset in range(0, len(pixels), 3)
+            if max(pixels[offset : offset + 3])
+            != min(pixels[offset : offset + 3])
+        }
+        self.assertGreater(len(chromatic_colors), 16)
+
+    def test_indexed_primary_preserves_color_zwj_shaping(self):
+        with Shitty(
+            columns=2,
+            rows=1,
+            extra_arguments=("-fontsize", "32", "-border", "2"),
+        ) as terminal:
+            terminal.write(b"\x1b[?25l" + "👩‍💻".encode())
+            selected = None
+            for (
+                family,
+                filename,
+                index,
+                variants,
+                _,
+            ) in loadable_indexed_fontconfig_matches(terminal):
+                try:
+                    loaded = terminal.load_font(family, COLOR_FONT)
+                    width, height, pixels = terminal.render_image(
+                        family,
+                        COLOR_FONT,
+                    )
+                except RuntimeError:
+                    continue
+                selected = (
+                    filename,
+                    index,
+                    variants,
+                    loaded,
+                    width,
+                    height,
+                    pixels,
+                )
+                break
+            if selected is None:
+                self.skipTest(
+                    "no indexed collection resolves and loads with color fallback"
+                )
+            (
+                filename,
+                index,
+                variants,
+                loaded,
+                width,
+                height,
+                pixels,
+            ) = selected
+
+        self.assertEqual(
+            (variants["regular"], variants["regular_index"]),
+            (filename, index),
+        )
+        self.assertEqual(loaded["regular_face_index"], index)
+        self.assertEqual(loaded["double_width"], 1)
+        self.assertEqual(
+            (width, height),
+            (4 + 2 * loaded["px"], 4 + loaded["py"]),
         )
         chromatic_colors = {
             pixels[offset : offset + 3]

--- a/tests/test_font_resolver.py
+++ b/tests/test_font_resolver.py
@@ -3,14 +3,127 @@
 # See the file LICENSE.MIT for the full license.
 
 import os
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from harness import Shitty
 
 
 ROOT = Path(__file__).resolve().parents[1]
 COLOR_FONT = ROOT / "tests" / "fonts" / "NotoColorEmoji.ttf"
+
+
+def run_fontconfig(*arguments):
+    try:
+        return subprocess.run(
+            arguments,
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise unittest.SkipTest(
+            f"{arguments[0]} is unavailable; fontconfig discovery cannot run"
+        ) from error
+    except subprocess.CalledProcessError as error:
+        raise unittest.SkipTest(
+            f"{arguments[0]} failed; fontconfig discovery cannot run"
+        ) from error
+
+
+def indexed_fontconfig_matches():
+    for family in fontconfig_families():
+        matched = run_fontconfig(
+            "fc-match", "--format=%{file}\n%{index}\n", family
+        )
+        fields = matched.stdout.splitlines()
+        if len(fields) != 2:
+            continue
+        try:
+            index = int(fields[1])
+        except ValueError:
+            continue
+        if fields[0] and index > 0:
+            yield family, fields[0], index
+
+
+def fontconfig_families():
+    listed = run_fontconfig(
+        "fc-list", "--format=%{family[0]}\n"
+    )
+    return tuple(sorted(
+        family for family in set(listed.stdout.splitlines()) if family
+    ))
+
+
+def loadable_fontconfig_matches(terminal, families=None):
+    candidates = (
+        fontconfig_families()
+        if families is None
+        else tuple(sorted(set(families)))
+    )
+    for family in candidates:
+        try:
+            variants = terminal.resolve_fontconfig(family)
+            if not variants["regular"]:
+                continue
+            loaded = terminal.load_font(family, "")
+        except RuntimeError:
+            continue
+        yield family, variants, loaded
+
+
+def loadable_indexed_fontconfig_matches(terminal):
+    for family, filename, index in indexed_fontconfig_matches():
+        try:
+            variants = terminal.resolve_fontconfig(family)
+            if face_from_variants(variants, "regular") != (filename, index):
+                continue
+            loaded = terminal.load_font(family, "")
+        except RuntimeError:
+            continue
+        if loaded["regular_face_index"] == index:
+            yield family, filename, index, variants, loaded
+
+
+def face_from_variants(variants, name):
+    return variants[name], variants[name + "_index"]
+
+
+def write_bitmap_font(path, width, ascent, descent):
+    height = ascent + descent
+    bitmap_row = "00" * ((width + 7) // 8)
+    bitmap = "\n".join(bitmap_row for _ in range(height))
+    path.write_text(
+        f"""STARTFONT 2.1
+FONT -misc-shitty-test-medium-r-normal--{height}-160-75-75-c-{width * 10}-iso10646-1
+SIZE {height} 75 75
+FONTBOUNDINGBOX {width} {height} 0 -{descent}
+STARTPROPERTIES 7
+FONT_ASCENT {ascent}
+FONT_DESCENT {descent}
+PIXEL_SIZE {height}
+POINT_SIZE {height * 10}
+RESOLUTION_X 75
+RESOLUTION_Y 75
+AVERAGE_WIDTH {width * 10}
+ENDPROPERTIES
+CHARS 1
+STARTCHAR M
+ENCODING 77
+SWIDTH 500 0
+DWIDTH {width} 0
+BBX {width} {height} 0 -{descent}
+BITMAP
+{bitmap}
+ENDCHAR
+ENDFONT
+""",
+        encoding="ascii",
+    )
 
 
 class FontResolverTest(unittest.TestCase):
@@ -26,19 +139,79 @@ class FontResolverTest(unittest.TestCase):
 
     def test_fontconfig_resolves_family_and_alias_to_existing_files(self):
         with Shitty() as terminal:
-            for family in ("monospace", "IBM Plex Mono"):
+            installed = next(
+                loadable_fontconfig_matches(terminal),
+                None,
+            )
+            if installed is None:
+                self.skipTest(
+                    "no installed fontconfig family resolves and loads"
+                )
+            for family in ("monospace", installed[0]):
                 with self.subTest(family=family):
-                    variants = terminal.resolve_fontconfig(family)
+                    selected = next(
+                        loadable_fontconfig_matches(terminal, (family,)),
+                        None,
+                    )
+                    self.assertIsNotNone(selected)
+                    _, variants, _ = selected
                     self.assertTrue(variants["regular"])
                     self.assertTrue(os.path.isfile(variants["regular"]))
 
     def test_fontconfig_loads_all_four_style_faces_when_available(self):
         with Shitty() as terminal:
-            loaded = terminal.load_font("IBM Plex Mono", "")
-        self.assertEqual(
-            (loaded["bold"], loaded["italic"], loaded["bold_italic"]),
-            (1, 1, 1),
-        )
+            for _, variants, loaded in loadable_fontconfig_matches(terminal):
+                if not all(
+                    variants[name]
+                    for name in ("regular", "bold", "italic", "bold_italic")
+                ):
+                    continue
+                if (
+                    loaded["bold"],
+                    loaded["italic"],
+                    loaded["bold_italic"],
+                ) == (1, 1, 1):
+                    break
+            else:
+                self.skipTest("no compatible four-face family is installed")
+
+    def test_fontconfig_discovery_continues_after_unusable_candidate(self):
+        candidates = ("!shitty-missing-test-family!", "monospace")
+        with Shitty() as terminal:
+            selected = list(
+                loadable_fontconfig_matches(terminal, candidates)
+            )
+        self.assertEqual([match[0] for match in selected], ["monospace"])
+
+    def test_fontconfig_list_absence_is_a_deliberate_skip(self):
+        with mock.patch.object(
+            subprocess,
+            "run",
+            side_effect=FileNotFoundError,
+        ):
+            with self.assertRaisesRegex(
+                unittest.SkipTest,
+                "fc-list is unavailable",
+            ):
+                fontconfig_families()
+
+    def test_fontconfig_match_absence_is_a_deliberate_skip(self):
+        with (
+            mock.patch(
+                __name__ + ".fontconfig_families",
+                return_value=("monospace",),
+            ),
+            mock.patch.object(
+                subprocess,
+                "run",
+                side_effect=FileNotFoundError,
+            ),
+        ):
+            with self.assertRaisesRegex(
+                unittest.SkipTest,
+                "fc-match is unavailable",
+            ):
+                list(indexed_fontconfig_matches())
 
     def test_fontconfig_family_loads_without_a_search_path(self):
         with Shitty() as terminal:
@@ -54,6 +227,187 @@ class FontResolverTest(unittest.TestCase):
         self.assertEqual(variants["regular"], str(COLOR_FONT))
         self.assertLessEqual(primary["py"], 64)
         self.assertEqual(fallback["double_width"], 1)
+
+    def test_fontconfig_preserves_collection_face_index(self):
+        with Shitty() as terminal:
+            match = next(
+                loadable_indexed_fontconfig_matches(terminal),
+                None,
+            )
+            if match is None:
+                self.skipTest(
+                    "no indexed collection resolves and loads"
+                )
+            _, filename, index, variants, loaded = match
+            metrics = terminal.font_face_metrics(filename, index, ord("M"))
+
+        self.assertEqual(variants["regular"], filename)
+        self.assertEqual(variants["regular_index"], index)
+        self.assertEqual(metrics["face_index"], index)
+        self.assertEqual(loaded["regular_face_index"], index)
+
+    def test_collection_font_uses_single_and_double_width_advances(self):
+        loaded = None
+        primary_metrics = None
+        double_width_metrics = None
+        selected_family = None
+        with Shitty() as terminal:
+            for (
+                family,
+                _,
+                _,
+                variants,
+                _,
+            ) in loadable_indexed_fontconfig_matches(terminal):
+                primary_face = face_from_variants(variants, "regular")
+                primary = terminal.font_face_metrics(*primary_face, ord("M"))
+                double_width = terminal.font_face_metrics(
+                    *primary_face, 0x3000
+                )
+                if not (
+                    primary["valid"]
+                    and primary["has_glyph"]
+                    and double_width["has_glyph"]
+                    and primary["advance"] != primary["max_advance"]
+                    and double_width["advance"] != double_width["max_advance"]
+                    and double_width["advance"] == 2 * primary["advance"]
+                ):
+                    continue
+                try:
+                    loaded = terminal.load_font(family, family)
+                except RuntimeError:
+                    continue
+                primary_metrics = primary
+                double_width_metrics = double_width
+                selected_family = family
+                break
+        if loaded is None:
+            self.skipTest(
+                "no indexed collection distinguishes cell and maximum advances"
+            )
+
+        self.assertEqual(
+            loaded["px"], primary_metrics["advance"], selected_family
+        )
+        self.assertEqual(loaded["double_width"], 1, selected_family)
+        self.assertEqual(
+            loaded["double_width_face_index"],
+            loaded["regular_face_index"],
+            selected_family,
+        )
+        self.assertEqual(
+            2 * loaded["px"],
+            double_width_metrics["advance"],
+            selected_family,
+        )
+        self.assertEqual(
+            primary_metrics["py"],
+            loaded["py"],
+            selected_family,
+        )
+
+    def test_scaled_overlay_keeps_primary_cell_width(self):
+        selected = None
+        with Shitty() as terminal:
+            for (
+                _,
+                variants,
+                _,
+            ) in loadable_fontconfig_matches(terminal):
+                primary_face = face_from_variants(variants, "regular")
+                primary = terminal.font_face_metrics(*primary_face, ord("M"))
+                if not primary["valid"] or not primary["has_glyph"]:
+                    continue
+                for name in ("bold", "italic", "bold_italic"):
+                    overlay_face = face_from_variants(variants, name)
+                    if not overlay_face[0]:
+                        continue
+                    overlay = terminal.font_face_metrics(
+                        *overlay_face, ord("M")
+                    )
+                    if (
+                        overlay["valid"]
+                        and overlay["has_glyph"]
+                        and (overlay["py"], overlay["baseline"])
+                        == (primary["py"], primary["baseline"])
+                        and overlay["max_advance"] != primary["advance"]
+                    ):
+                        selected = primary_face, overlay_face, primary, overlay
+                        break
+                if selected is not None:
+                    break
+            if selected is None:
+                self.skipTest(
+                    "no scalable overlay with distinct width metrics is installed"
+                )
+            primary_face, overlay_face, primary, overlay = selected
+            loaded_overlay = terminal.load_overlay(
+                *primary_face, *overlay_face
+            )
+
+        self.assertNotEqual(overlay["max_advance"], primary["advance"])
+        self.assertEqual(
+            (overlay["py"], overlay["baseline"]),
+            (primary["py"], primary["baseline"]),
+        )
+        self.assertTrue(loaded_overlay["compatible"])
+        self.assertEqual(loaded_overlay["px"], primary["advance"])
+
+    def test_scaled_overlay_rejects_vertical_metric_mismatch(self):
+        selected = None
+        candidates = []
+        with Shitty() as terminal:
+            for (
+                _,
+                variants,
+                _,
+            ) in loadable_fontconfig_matches(terminal):
+                face = face_from_variants(variants, "regular")
+                metrics = terminal.font_face_metrics(*face, ord("M"))
+                if not metrics["valid"] or not metrics["has_glyph"]:
+                    continue
+                for primary_face, primary in candidates:
+                    if (metrics["py"], metrics["baseline"]) != (
+                        primary["py"],
+                        primary["baseline"],
+                    ):
+                        selected = primary_face, face
+                        break
+                if selected is not None:
+                    break
+                candidates.append((face, metrics))
+            if selected is None:
+                self.skipTest(
+                    "no scalable faces with distinct vertical metrics are installed"
+                )
+            loaded_overlay = terminal.load_overlay(*selected[0], *selected[1])
+
+        self.assertFalse(loaded_overlay["compatible"])
+
+    def test_fixed_overlay_inherits_width_and_checks_baseline(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            primary = root / "primary.bdf"
+            wide_overlay = root / "wide-overlay.bdf"
+            shifted_overlay = root / "shifted-overlay.bdf"
+            write_bitmap_font(primary, width=8, ascent=12, descent=4)
+            write_bitmap_font(wide_overlay, width=10, ascent=12, descent=4)
+            write_bitmap_font(shifted_overlay, width=10, ascent=11, descent=5)
+
+            with Shitty() as terminal:
+                compatible = terminal.load_overlay(
+                    primary, 0, wide_overlay, 0
+                )
+                incompatible = terminal.load_overlay(
+                    primary, 0, shifted_overlay, 0
+                )
+
+        self.assertTrue(compatible["compatible"])
+        self.assertEqual(
+            (compatible["px"], compatible["py"], compatible["baseline"]),
+            (8, 16, 12),
+        )
+        self.assertFalse(incompatible["compatible"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- preserve Fontconfig `(file, index)` identities through resolution, Fontpack construction, and FreeType loading so TTC and OTC selections open the exact collection face
- derive scalable primary and double-width cells from representative `M` and U+3000 advances, using the font-wide maximum only when the representative glyph is unavailable
- retain the primary cell width for fixed and scalable overlays while enforcing compatible height and baseline metrics
- preserve multi-codepoint HarfBuzz shaping and intrinsic-color fallback rendering, including legacy fixed-color mask baseline behavior
- make installed-font discovery deterministic, continue past unusable candidates, and skip explicitly when Fontconfig discovery commands are unavailable

Closes #4

## Verification

- focused TTC and color suite: 16 tests passed, 2 subtests passed
- native suite: 762 tests passed
- `st_test` build passed
- production `st` build passed
- `git diff --check`
