### PR TITLE
Fix stray window from st -v version probe and set a stable app_id

### DIFF
--- a/options.cpp
+++ b/options.cpp
@@ -79,6 +79,7 @@ namespace {
         {"showWraps", OptionKind::NoArg, "true", "false", "Show wrap marks at right margin"},
         {"title", OptionKind::SepArg, nullptr, "Shitty", "Window title"},
         {"verbose", OptionKind::NoArg, "true", "false", "Output info messages"},
+        {"version", OptionKind::NoArg, "true", "false", "Print version and quit"},
         {"e", OptionKind::SkipLine, nullptr, nullptr, "Command line to run"},
     };
 
@@ -121,7 +122,7 @@ namespace {
 
     const OptionDesc* findOption(const char* prefix) {
         if (strcmp(prefix, "v") == 0) {
-            prefix = "verbose";
+            prefix = "version";
         }
 
         const OptionDesc* found = nullptr;
@@ -372,6 +373,10 @@ int Options::getInteger(const char* name, int min, int max) {
 }
 
 void Options::handlePrintOpts() {
+    if (getBool("version")) {
+        printVersion();
+        exit(0);
+    }
     if (getBool("help")) {
         printUsage();
         exit(0);

--- a/shitty.desktop
+++ b/shitty.desktop
@@ -5,5 +5,6 @@ Comment=Cross-platform terminal with Vulkan rendering
 Exec=st
 Terminal=false
 Icon=shitty
+StartupWMClass=shitty
 Categories=System;TerminalEmulator;
 Keywords=shell;prompt;command;commandline;cmd;

--- a/window.cpp
+++ b/window.cpp
@@ -212,6 +212,9 @@ void WindowImpl::initialize() {
     glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_TRUE);
+    glfwWindowHintString(GLFW_WAYLAND_APP_ID, "shitty");
+    glfwWindowHintString(GLFW_X11_CLASS_NAME, "shitty");
+    glfwWindowHintString(GLFW_X11_INSTANCE_NAME, "shitty");
     const int initialWidth = max(320, (int)(opts.nCols) * opts.fontsize / 2);
     const int initialHeight = max(200, (int)(opts.nRows) * opts.fontsize);
     window = glfwCreateWindow(initialWidth, initialHeight, opts.title, nullptr, nullptr);


### PR DESCRIPTION
Two independent fixes:

- Make \`-v\` print the version and exit (suckless-compatible), so version probes like fastfetch's no longer spawn a stray terminal window.
- Advertise a stable "shitty" app_id / WM_CLASS so the window matches shitty.desktop for its icon and task grouping.