### PR TITLE
Add Nix flake packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@
 /unit_tests
 /test_suite
 /main_fuzz
+/result
+/result-*
 __pycache__/
+.codegraph/

--- a/README.md
+++ b/README.md
@@ -143,6 +143,30 @@ install -Dm644 shitty.svg \
 `Exec=st` is resolved through `PATH`, while `Icon=shitty` is resolved through
 the active icon theme.
 
+### Nix
+
+A flake provides the `shitty` package and a development shell. Bundled
+submodules are fetched from pinned flake inputs, so a plain build works
+without `git submodule update`:
+
+```sh
+nix build           # ./result/bin/st
+nix run             # run st directly
+nix develop         # clang toolchain + build dependencies
+```
+
+Add the package to a NixOS system from the flake overlay or via:
+
+```nix
+{
+  inputs.shitty.url = "github:pg83/shitty";
+  # ...
+  environment.systemPackages = [ inputs.shitty.packages.${system}.default ];
+}
+```
+
+`shell.nix` remains available for `nix-shell` without flakes.
+
 ## Tests
 
 Run the full native and imported conformance suite:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "glfw-shitty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785164325,
+        "narHash": "sha256-KK5xVA6HomHSgxgTusDs1o41EcBC9FgtpTxPI7G+QSE=",
+        "owner": "pg83",
+        "repo": "glfw",
+        "rev": "a2b295420d899be60c6a27ced21eb172bf51f675",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pg83",
+        "repo": "glfw",
+        "rev": "a2b295420d899be60c6a27ced21eb172bf51f675",
+        "type": "github"
+      }
+    },
+    "libstd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784759405,
+        "narHash": "sha256-K209YAJSDrcadjFyI0/oL8W5nW/P5YtpJYUnwKtwfyY=",
+        "owner": "pg83",
+        "repo": "std",
+        "rev": "6ab662255eb2c459e5e69e13248c964eef5eedc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pg83",
+        "repo": "std",
+        "rev": "6ab662255eb2c459e5e69e13248c964eef5eedc1",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "glfw-shitty": "glfw-shitty",
+        "libstd": "libstd",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,197 @@
+# Copyright (C) 2026 Shitty team
+# MIT licensed
+# See the file LICENSE.MIT for the full license.
+{
+  description = "Shitty — a small, fast Wayland/Vulkan terminal emulator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # Pinned to the commits recorded in .gitmodules. Bump together with the
+    # submodules when either dependency moves.
+    libstd = {
+      url = "github:pg83/std/6ab662255eb2c459e5e69e13248c964eef5eedc1";
+      flake = false;
+    };
+    glfw-shitty = {
+      url = "github:pg83/glfw/a2b295420d899be60c6a27ced21eb172bf51f675";
+      flake = false;
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      libstd,
+      glfw-shitty,
+    }:
+    let
+      inherit (nixpkgs) lib;
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = lib.genAttrs systems;
+
+      nixpkgsFor = system: nixpkgs.legacyPackages.${system};
+
+      # YYYY.MM.DD from the flake's lastModifiedDate, matching build.py's scheme.
+      versionFromFlake =
+        let
+          d = self.lastModifiedDate or "19700101";
+        in
+        "${builtins.substring 0 4 d}.${builtins.substring 4 2 d}.${builtins.substring 6 2 d}";
+
+      mkShitty =
+        pkgs:
+        let
+          stdenv = pkgs.llvmPackages.stdenv;
+        in
+        stdenv.mkDerivation rec {
+          pname = "shitty";
+          version = versionFromFlake;
+
+          src = self;
+
+          # Flake source checkouts do not include git submodules. Populate the
+          # vendored trees from the pinned flake inputs so `nix build` works
+          # without `?submodules=1`.
+          postUnpack = ''
+            mkdir -p "$sourceRoot/third_party"
+            rm -rf "$sourceRoot/third_party/libstd" "$sourceRoot/third_party/glfw"
+            cp -a ${libstd} "$sourceRoot/third_party/libstd"
+            cp -a ${glfw-shitty} "$sourceRoot/third_party/glfw"
+            chmod -R u+w "$sourceRoot/third_party"
+          '';
+
+          # build.py stamps SHITTY_VERSION from date.today(), which is impure
+          # under the Nix sandbox. Pin it to the flake revision date instead.
+          postPatch = ''
+            substituteInPlace build.py \
+              --replace-fail 'date.today().strftime("%Y.%m.%d")' '"${version}"'
+          '';
+
+          nativeBuildInputs = with pkgs; [
+            addDriverRunpath
+            glslang
+            makeWrapper
+            pkg-config
+            python3
+            ragel
+            wayland-scanner
+          ];
+
+          buildInputs = with pkgs; [
+            brotli
+            fontconfig
+            freetype
+            harfbuzz
+            libxkbcommon
+            simdutf
+            utf8proc
+            vulkan-headers
+            vulkan-loader
+            wayland
+          ];
+
+          # The project's runner honours the usual toolchain env vars. Keep the
+          # build out of $src (read-only store path) via -B.
+          buildPhase = ''
+            runHook preBuild
+            python3 ./build -B .build -j "$NIX_BUILD_CORES"
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 .build/st "$out/bin/st"
+            install -Dm644 shitty.desktop \
+              "$out/share/applications/shitty.desktop"
+            install -Dm644 shitty.svg \
+              "$out/share/icons/hicolor/scalable/apps/shitty.svg"
+            runHook postInstall
+          '';
+
+          # Vulkan ICDs live under /run/opengl-driver on NixOS; addDriverRunpath
+          # puts that directory on the binary's RUNPATH.
+          postFixup = ''
+            addDriverRunpath "$out/bin/st"
+          '';
+
+          meta = {
+            description = "Small, fast terminal emulator with a Linux Wayland/Vulkan frontend";
+            homepage = "https://github.com/pg83/shitty";
+            license = with lib.licenses; [
+              gpl3Plus
+              mit
+            ];
+            mainProgram = "st";
+            platforms = lib.platforms.linux;
+            # Wayland + Vulkan compute frontend; no X11 backend.
+            badPlatforms = lib.platforms.darwin;
+          };
+        };
+
+      mkDevShell =
+        pkgs:
+        let
+          stdenv = pkgs.llvmPackages.stdenv;
+          shitty = mkShitty pkgs;
+        in
+        pkgs.mkShell.override { inherit stdenv; } {
+          inputsFrom = [ shitty ];
+
+          packages = with pkgs; [
+            clang-tools
+            gdb
+            # Fonts for manual runs inside the shell.
+            dejavu_fonts
+            ibm-plex
+          ];
+
+          FONTCONFIG_FILE = pkgs.makeFontsConf {
+            fontDirectories = with pkgs; [
+              dejavu_fonts
+              ibm-plex
+            ];
+          };
+
+          shellHook = ''
+            echo "shitty dev shell — run: ./build && ./st"
+          '';
+        };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor system;
+          shitty = mkShitty pkgs;
+        in
+        {
+          default = shitty;
+          shitty = shitty;
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor system;
+        in
+        {
+          default = mkDevShell pkgs;
+        }
+      );
+
+      formatter = forAllSystems (system: (nixpkgsFor system).nixfmt-rfc-style);
+
+      # Overlay so consumers can `pkgs.shitty` after importing the flake.
+      overlays.default = final: prev: {
+        shitty = mkShitty final;
+      };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,23 +1,38 @@
 # Copyright (C) 2026 Shitty team
 # MIT licensed
 # See the file LICENSE.MIT for the full license.
+#
+# Legacy entry point for `nix-shell`. Prefer `nix develop` from the flake.
+# Keep this package set aligned with flake.nix's mkDevShell / mkShitty.
 
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 (pkgs.mkShell.override { stdenv = pkgs.llvmPackages.stdenv; }) {
   FONTCONFIG_FILE = pkgs.makeFontsConf {
-    fontDirectories = [ pkgs.dejavu_fonts pkgs.ibm-plex ];
+    fontDirectories = [
+      pkgs.dejavu_fonts
+      pkgs.ibm-plex
+    ];
   };
 
   packages = with pkgs; [
     brotli
+    clang-tools
     fontconfig
     freetype
     glslang
-    glfw
+    harfbuzz
+    libxkbcommon
     pkg-config
     python3
+    ragel
+    simdutf
     utf8proc
+    vulkan-headers
     vulkan-loader
+    wayland
+    wayland-scanner
   ];
 }

--- a/test_mode.cpp
+++ b/test_mode.cpp
@@ -43,6 +43,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <deque>
 #include <fcntl.h>
 #include <functional>


### PR DESCRIPTION
## Summary

Adds a Nix flake so Shitty can be built and consumed without a manual toolchain setup:

- **`nix build` / `nix run`** — package installs `st`, `shitty.desktop`, and the SVG icon
- **`nix develop`** — Clang stdenv + complete build dependencies
- **`overlays.default`** — for NixOS / home-manager consumers
- Bundled `libstd` and `glfw` are pinned as flake inputs (same commits as `.gitmodules`), so a plain `nix build` works without `git submodule update` or `?submodules=1`
- `SHITTY_VERSION` is stamped from the flake's `lastModifiedDate` (avoids impure `date.today()` under the sandbox)
- Binary gets `addDriverRunpath` so Vulkan ICDs resolve on NixOS

Also:

- Completes `shell.nix` deps that the existing file was missing (`harfbuzz`, `wayland`, `libxkbcommon`, `ragel`, `wayland-scanner`, `simdutf`, `vulkan-headers`)
- Documents the Nix workflow in `README.md`
- Ignores `/result` and `/result-*`
- Fixes a missing `#include <cstring>` in `test_mode.cpp` (`strlen` undeclared under current clang) — required for the package to compile

## Test plan

- [x] `nix build` succeeds on `x86_64-linux`
- [x] `./result/bin/st -v` prints `Shitty 2026.07.27`
- [x] `./result/bin/st -help` prints the option list
- [x] `ldd ./result/bin/st` resolves `libvulkan`, Wayland, FreeType, HarfBuzz, utf8proc, simdutf from the Nix store
- [ ] `nix run` opens a window under a Wayland compositor (not exercised in this CI-less environment)
- [ ] `nix develop` then `./build` matches the non-Nix workflow

## Notes for maintainers

When bumping `third_party/libstd` or `third_party/glfw`, also bump the corresponding flake input URL revs in `flake.nix` and run `nix flake lock` so the pins stay aligned with `.gitmodules`.