### PR TITLE
Improve semantic word selection

### DIFF
--- a/screen.cpp
+++ b/screen.cpp
@@ -381,9 +381,10 @@ namespace {
         static constexpr size_t cellSize = sizeof(TerminalCell);
     };
 
+    constexpr u32 whitespaceClass = 0x110000;
+    constexpr u32 identifierClass = 0x110001;
+
     u32 wordClass(u32 codepoint) {
-        constexpr u32 whitespaceClass = 0x110000;
-        constexpr u32 identifierClass = 0x110001;
         switch (utf8proc_category(codepoint)) {
             case UTF8PROC_CATEGORY_LU:
             case UTF8PROC_CATEGORY_LL:
@@ -407,6 +408,244 @@ namespace {
                 // a useful selectable run, while unlike punctuation stays split.
                 return codepoint;
         }
+    }
+
+    struct SelectionRow {
+        const TerminalCell* cells;
+        int columns;
+    };
+
+    struct TokenBounds {
+        int left;
+        int right;
+    };
+
+    int selectionCellLead(const SelectionRow& row, int column) {
+        column = std::max(0, std::min(column, row.columns - 1));
+        return row.cells[column].dwidth_cont && column > 0 ? column - 1 : column;
+    }
+
+    u32 selectionCodepoint(const SelectionRow& row, int column) {
+        const u32 codepoint = row.cells[selectionCellLead(row, column)].uc_pt;
+        return codepoint == 0 ? (u32)(' ') : codepoint;
+    }
+
+    int nextSelectionCell(const SelectionRow& row, int column) {
+        const int lead = selectionCellLead(row, column);
+        return std::min(row.columns, lead + (row.cells[lead].dwidth ? 2 : 1));
+    }
+
+    int previousSelectionCell(const SelectionRow& row, int column) {
+        return selectionCellLead(row, std::max(0, column - 1));
+    }
+
+    bool identifierCodepoint(u32 codepoint) {
+        return wordClass(codepoint) == identifierClass;
+    }
+
+    bool asciiAlpha(u32 codepoint) {
+        return (codepoint >= 'a' && codepoint <= 'z') || (codepoint >= 'A' && codepoint <= 'Z');
+    }
+
+    bool uriCodepoint(u32 codepoint) {
+        return identifierCodepoint(codepoint) || (codepoint < 0x80 && std::strchr("-._~:/?#[]@!$&'()*+,;=%", (int)(codepoint)) != nullptr);
+    }
+
+    bool uriSchemeCodepoint(u32 codepoint) {
+        return asciiAlpha(codepoint) || (codepoint >= '0' && codepoint <= '9') || codepoint == '+' || codepoint == '-' || codepoint == '.';
+    }
+
+    bool compoundCodepoint(u32 codepoint) {
+        return identifierCodepoint(codepoint) || codepoint == '.' || codepoint == '-' || codepoint == '/' || codepoint == ':' || codepoint == '@' || codepoint == '\\' || codepoint == '~';
+    }
+
+    TokenBounds expandTokenRun(const SelectionRow& row, int column, bool (*included)(u32)) {
+        int left = selectionCellLead(row, column);
+        if (!included(selectionCodepoint(row, left))) {
+            return {left, left};
+        }
+        while (left > 0) {
+            const int previous = previousSelectionCell(row, left);
+            if (!included(selectionCodepoint(row, previous))) {
+                break;
+            }
+            left = previous;
+        }
+
+        int right = left;
+        while (right < row.columns && included(selectionCodepoint(row, right))) {
+            right = nextSelectionCell(row, right);
+        }
+        return {left, right};
+    }
+
+    bool unmatchedClosingDelimiter(const SelectionRow& row, int left, int right, u32 opening, u32 closing) {
+        int balance = 0;
+        for (int column = left; column < right; column = nextSelectionCell(row, column)) {
+            const u32 codepoint = selectionCodepoint(row, column);
+            balance += codepoint == opening;
+            balance -= codepoint == closing;
+        }
+        return balance < 0;
+    }
+
+    int schemeLessUriLeft(const SelectionRow& row, const TokenBounds& run) {
+        int candidate = -1;
+        bool hasDot = false;
+        bool previousDot = false;
+        for (int cursor = run.left; cursor < run.right; cursor = nextSelectionCell(row, cursor)) {
+            const u32 codepoint = selectionCodepoint(row, cursor);
+            if (identifierCodepoint(codepoint)) {
+                if (candidate < 0) {
+                    candidate = cursor;
+                }
+                previousDot = false;
+                continue;
+            }
+            if (codepoint == '-' && candidate >= 0) {
+                previousDot = false;
+                continue;
+            }
+            if (codepoint == '.' && candidate >= 0 && !previousDot) {
+                hasDot = true;
+                previousDot = true;
+                continue;
+            }
+            if (codepoint == '/' && candidate >= 0 && hasDot && !previousDot) {
+                return candidate;
+            }
+            candidate = -1;
+            hasDot = false;
+            previousDot = false;
+        }
+        return -1;
+    }
+
+    TokenBounds uriTokenBounds(const SelectionRow& row, int column) {
+        const int clicked = selectionCellLead(row, column);
+        const TokenBounds run = expandTokenRun(row, clicked, uriCodepoint);
+        if (run.left == run.right) {
+            return {clicked, clicked};
+        }
+
+        int schemeLeft = -1;
+        int uriLeft = -1;
+        for (int cursor = run.left; cursor < run.right; cursor = nextSelectionCell(row, cursor)) {
+            const u32 codepoint = selectionCodepoint(row, cursor);
+            if (schemeLeft < 0) {
+                if (asciiAlpha(codepoint)) {
+                    schemeLeft = cursor;
+                }
+                continue;
+            }
+            if (uriSchemeCodepoint(codepoint)) {
+                continue;
+            }
+            if (codepoint != ':') {
+                schemeLeft = -1;
+                continue;
+            }
+            const int firstSlash = nextSelectionCell(row, cursor);
+            const int secondSlash = firstSlash < run.right ? nextSelectionCell(row, firstSlash) : run.right;
+            if (firstSlash < run.right && selectionCodepoint(row, firstSlash) == '/' && secondSlash < run.right && selectionCodepoint(row, secondSlash) == '/') {
+                uriLeft = schemeLeft;
+                break;
+            }
+            schemeLeft = -1;
+        }
+        if (uriLeft < 0) {
+            uriLeft = schemeLessUriLeft(row, run);
+        }
+        if (uriLeft < 0 || clicked < uriLeft) {
+            return {clicked, clicked};
+        }
+
+        int uriRight = run.right;
+        while (uriRight > uriLeft) {
+            const int last = previousSelectionCell(row, uriRight);
+            const u32 codepoint = selectionCodepoint(row, last);
+            const bool trailingPunctuation = codepoint == '.' || codepoint == ',' || codepoint == ';' || codepoint == ':' || codepoint == '!' || codepoint == '?' || codepoint == '\'';
+            const bool unmatchedBracket = (codepoint == ')' && unmatchedClosingDelimiter(row, uriLeft, uriRight, '(', ')')) || (codepoint == ']' && unmatchedClosingDelimiter(row, uriLeft, uriRight, '[', ']'));
+            if (!trailingPunctuation && !unmatchedBracket) {
+                break;
+            }
+            uriRight = last;
+        }
+        return clicked < uriRight ? TokenBounds{uriLeft, uriRight} : TokenBounds{clicked, clicked};
+    }
+
+    bool validCompoundPrefix(const SelectionRow& row, int left, int firstIdentifier) {
+        const u32 first = selectionCodepoint(row, left);
+        const int secondColumn = nextSelectionCell(row, left);
+        if (secondColumn == firstIdentifier) {
+            return first == '/' || first == '\\' || first == '.' || first == '-' || first == '@';
+        }
+
+        const u32 second = selectionCodepoint(row, secondColumn);
+        const int thirdColumn = nextSelectionCell(row, secondColumn);
+        if (thirdColumn == firstIdentifier) {
+            return (first == '~' && (second == '/' || second == '\\')) || (first == '.' && (second == '/' || second == '\\')) || (first == '-' && second == '-');
+        }
+
+        const u32 third = selectionCodepoint(row, thirdColumn);
+        const int fourthColumn = nextSelectionCell(row, thirdColumn);
+        return fourthColumn == firstIdentifier && first == '.' && second == '.' && (third == '/' || third == '\\');
+    }
+
+    TokenBounds compoundTokenBounds(const SelectionRow& row, int column) {
+        const int clicked = selectionCellLead(row, column);
+        if (!identifierCodepoint(selectionCodepoint(row, clicked))) {
+            return {clicked, clicked};
+        }
+
+        TokenBounds token = expandTokenRun(row, clicked, compoundCodepoint);
+        while (token.right > token.left) {
+            const int last = previousSelectionCell(row, token.right);
+            const u32 codepoint = selectionCodepoint(row, last);
+            if (identifierCodepoint(codepoint) || codepoint == '/' || codepoint == '\\') {
+                break;
+            }
+            token.right = last;
+        }
+
+        int firstIdentifier = token.left;
+        while (firstIdentifier < token.right && !identifierCodepoint(selectionCodepoint(row, firstIdentifier))) {
+            firstIdentifier = nextSelectionCell(row, firstIdentifier);
+        }
+        if (firstIdentifier == token.right || clicked >= token.right) {
+            return {clicked, clicked};
+        }
+
+        if (firstIdentifier != token.left && !validCompoundPrefix(row, token.left, firstIdentifier)) {
+            token.left = firstIdentifier;
+        }
+        return token;
+    }
+
+    TokenBounds semanticTokenBounds(const SelectionRow& row, int column) {
+        const TokenBounds uri = uriTokenBounds(row, column);
+        if (uri.left != uri.right) {
+            return uri;
+        }
+        return compoundTokenBounds(row, column);
+    }
+
+    TokenBounds wordTokenBounds(const SelectionRow& row, int column) {
+        int left = selectionCellLead(row, column);
+        const u32 selectedClass = wordClass(selectionCodepoint(row, left));
+        while (left > 0) {
+            const int previous = previousSelectionCell(row, left);
+            if (wordClass(selectionCodepoint(row, previous)) != selectedClass) {
+                break;
+            }
+            left = previous;
+        }
+
+        int right = left;
+        while (right < row.columns && wordClass(selectionCodepoint(row, right)) == selectedClass) {
+            right = nextSelectionCell(row, right);
+        }
+        return {left, right};
     }
 
     // A column shrink can copy the leading half of a wide glyph while
@@ -1310,37 +1549,79 @@ Rect ScreenImpl<Coord, Epoch>::getSnappedSelection() const {
         case SelectSnapTo::Char:
             break;
         case SelectSnapTo::Word: {
-            const auto cellLead = [this](const TerminalCell* row, int x) {
-                x = std::max(0, std::min(x, (int)(nCols)-1));
-                return row[x].dwidth_cont && x > 0 ? x - 1 : x;
-            };
-            const auto expand = [this, &cellLead](int rowIndex, int x) {
-                const auto* row = getLogicalRowPtr(rowIndex);
-                int left = cellLead(row, x);
-                const u32 selectedClass = wordClass(row[left].uc_pt ? row[left].uc_pt : ' ');
-                while (left > 0) {
-                    const int previous = cellLead(row, left - 1);
-                    const u32 codepoint = row[previous].uc_pt ? row[previous].uc_pt : ' ';
-                    if (wordClass(codepoint) != selectedClass) {
-                        break;
+            const auto expand = [this](int rowIndex, int column) {
+                const auto wrapLength = [this](int logicalRow) {
+                    const TerminalCell* cells = getLogicalRowPtr(logicalRow);
+                    for (int x = 0; x < nCols; ++x) {
+                        if (cells[x].wrap) {
+                            return x + 1;
+                        }
                     }
-                    left = previous;
+                    return 0;
+                };
+
+                const int currentWrapLength = wrapLength(rowIndex);
+                if (currentWrapLength != 0 && column >= currentWrapLength) {
+                    const SelectionRow row{getLogicalRowPtr(rowIndex), (int)(nCols)};
+                    const TokenBounds word = wordTokenBounds(row, column);
+                    return Rect(word.left, rowIndex, word.right, rowIndex);
                 }
 
-                int right = left;
-                while (right < nCols) {
-                    const int lead = cellLead(row, right);
-                    const u32 codepoint = row[lead].uc_pt ? row[lead].uc_pt : ' ';
-                    if (wordClass(codepoint) != selectedClass) {
+                int firstRow = rowIndex;
+                while (firstRow > -(int)(historyRows) && wrapLength(firstRow - 1) != 0) {
+                    --firstRow;
+                }
+                int lastRow = rowIndex;
+                while (lastRow + 1 < nRows && wrapLength(lastRow) != 0) {
+                    ++lastRow;
+                }
+
+                struct RowSpan {
+                    int row;
+                    int offset;
+                    int length;
+                };
+                std::vector<RowSpan> spans;
+                std::vector<TerminalCell> cells;
+                int clicked = -1;
+                for (int logicalRow = firstRow; logicalRow <= lastRow; ++logicalRow) {
+                    const int wrapped = wrapLength(logicalRow);
+                    const int length = wrapped != 0 ? wrapped : (int)(nCols);
+                    const int offset = cells.size();
+                    const TerminalCell* source = getLogicalRowPtr(logicalRow);
+                    cells.insert(cells.end(), source, source + length);
+                    spans.push_back({logicalRow, offset, length});
+                    if (logicalRow == rowIndex) {
+                        clicked = offset + column;
+                    }
+                }
+
+                const SelectionRow logicalLine{cells.data(), (int)(cells.size())};
+                const TokenBounds semantic = semanticTokenBounds(logicalLine, clicked);
+                if (semantic.left == semantic.right) {
+                    const SelectionRow row{getLogicalRowPtr(rowIndex), (int)(nCols)};
+                    const TokenBounds word = wordTokenBounds(row, column);
+                    return Rect(word.left, rowIndex, word.right, rowIndex);
+                }
+
+                Point left;
+                Point right;
+                for (const RowSpan& span : spans) {
+                    if (semantic.left >= span.offset && semantic.left < span.offset + span.length) {
+                        left = Point(semantic.left - span.offset, span.row);
+                    }
+                    if (semantic.right >= span.offset && semantic.right <= span.offset + span.length) {
+                        right = Point(semantic.right - span.offset, span.row);
                         break;
                     }
-                    right = lead + (row[lead].dwidth ? 2 : 1);
                 }
-                return std::pair<int, int>{left, right};
+                return Rect(left, right);
             };
 
-            ret.tl.x = expand(ret.tl.y, ret.tl.x).first;
-            ret.br.x = expand(ret.br.y, ret.br.x).second;
+            const Rect start = expand(ret.tl.y, ret.tl.x);
+            const Rect end = expand(ret.br.y, ret.br.x);
+            ret.tl = start.tl;
+            ret.br = end.br;
         } break;
         case SelectSnapTo::Line:
             ret.tl.x = 0;

--- a/tests/test_selection_word_unicode.py
+++ b/tests/test_selection_word_unicode.py
@@ -7,12 +7,13 @@ import unittest
 from harness import Shitty
 
 
-def double_click(terminal, column, time=1.0):
+def double_click(terminal, column, row=0, time=1.0):
     x = column + 2
-    terminal.button(0, True, x=x, y=2, time=time)
-    terminal.button(0, False, x=x, y=2, time=time + 0.01)
-    terminal.button(0, True, x=x, y=2, time=time + 0.1)
-    return terminal.button(0, False, x=x, y=2, time=time + 0.11)
+    y = row + 2
+    terminal.button(0, True, x=x, y=y, time=time)
+    terminal.button(0, False, x=x, y=y, time=time + 0.01)
+    terminal.button(0, True, x=x, y=y, time=time + 0.1)
+    return terminal.button(0, False, x=x, y=y, time=time + 0.11)
 
 
 class SelectionWordUnicodeTest(unittest.TestCase):
@@ -33,6 +34,113 @@ class SelectionWordUnicodeTest(unittest.TestCase):
         with Shitty(columns=16, rows=2) as terminal:
             terminal.write(b"one baz_qux two")
             self.assertEqual(double_click(terminal, 7), b"baz_qux")
+
+    def test_compound_identifiers_expand_from_identifier_characters(self):
+        cases = [
+            (b"namespace::symbol", 12),
+            (b"object.member", 8),
+            (b"some-name", 6),
+            (b"user@example.com", 6),
+        ]
+        for text, column in cases:
+            with self.subTest(text=text):
+                with Shitty(columns=32, rows=2) as terminal:
+                    terminal.write(text)
+                    self.assertEqual(double_click(terminal, column), text)
+
+    def test_compound_punctuation_keeps_direct_click_behavior(self):
+        with Shitty(columns=16, rows=2) as terminal:
+            terminal.write(b"namespace::symbol")
+            self.assertEqual(double_click(terminal, 9), b"::")
+        with Shitty(columns=16, rows=2) as terminal:
+            terminal.write(b"some-name")
+            self.assertEqual(double_click(terminal, 4), b"-")
+
+    def test_compound_tokens_exclude_prose_prefixes(self):
+        cases = [
+            (b"...object.member", 3, b"object.member"),
+            (b"...object.member", 10, b"object.member"),
+            (b"---foo", 3, b"foo"),
+        ]
+        for text, column, expected in cases:
+            with self.subTest(text=text, column=column):
+                with Shitty(columns=32, rows=2) as terminal:
+                    terminal.write(text)
+                    self.assertEqual(double_click(terminal, column), expected)
+
+    def test_compound_tokens_preserve_valid_prefixes(self):
+        cases = [
+            (b"./source.cpp", 2),
+            (b"../source.cpp", 3),
+            (b".git/config", 1),
+            (b"--verbose", 3),
+        ]
+        for text, column in cases:
+            with self.subTest(text=text):
+                with Shitty(columns=32, rows=2) as terminal:
+                    terminal.write(text)
+                    self.assertEqual(double_click(terminal, column), text)
+
+    def test_path_location_expands_from_an_identifier_character(self):
+        with Shitty(columns=40, rows=2) as terminal:
+            token = b"/home/user/source.cpp:42"
+            terminal.write(b"(" + token + b") next")
+            self.assertEqual(double_click(terminal, 8), token)
+
+    def test_uri_excludes_surrounding_punctuation(self):
+        with Shitty(columns=64, rows=2) as terminal:
+            uri = b"https://example.com/path?key=value#section"
+            terminal.write(b"(" + uri + b").")
+            self.assertEqual(double_click(terminal, 10), uri)
+
+    def test_uri_expands_when_clicking_uri_punctuation(self):
+        with Shitty(columns=40, rows=2) as terminal:
+            uri = b"https://example.com/path"
+            terminal.write(uri)
+            self.assertEqual(double_click(terminal, 6), uri)
+
+    def test_uri_excludes_complete_trailing_prose_suffix(self):
+        uri = b"https://example.com/a:b"
+        for opening, suffix in [(b"(", b"):"), (b"[", b"]:"), (b"", b":")]:
+            with self.subTest(suffix=suffix):
+                with Shitty(columns=48, rows=2) as terminal:
+                    terminal.write(opening + uri + suffix + b" next")
+                    self.assertEqual(double_click(terminal, len(opening) + 10), uri)
+
+    def test_semantic_selection_crosses_soft_wrapped_rows(self):
+        cases = [
+            (6, b"https://example.com", [(1, 0), (1, 1), (4, 2)]),
+            (7, b"object.member", [(2, 0), (1, 1)]),
+            (7, "object.東京".encode(), [(2, 0), (1, 1), (2, 1)]),
+        ]
+        for columns, text, clicks in cases:
+            for column, row in clicks:
+                with self.subTest(text=text, column=column, row=row):
+                    with Shitty(columns=columns, rows=4) as terminal:
+                        terminal.write(text)
+                        self.assertEqual(
+                            double_click(terminal, column, row),
+                            text,
+                        )
+
+    def test_scheme_less_url_expands_from_each_component(self):
+        uri = b"example.com/path?key=value#fragment"
+        for column in [2, 13, 18, 28]:
+            with self.subTest(column=column):
+                with Shitty(columns=48, rows=2) as terminal:
+                    terminal.write(uri)
+                    self.assertEqual(double_click(terminal, column), uri)
+
+    def test_question_and_equals_do_not_join_ordinary_prose(self):
+        cases = [
+            (b"what?maybe", 6, b"maybe"),
+            (b"alpha=beta", 7, b"beta"),
+        ]
+        for text, column, expected in cases:
+            with self.subTest(text=text):
+                with Shitty(columns=24, rows=2) as terminal:
+                    terminal.write(text)
+                    self.assertEqual(double_click(terminal, column), expected)
 
     def test_unicode_letters_and_marks_form_words(self):
         with Shitty(columns=20, rows=2) as terminal:


### PR DESCRIPTION
Improve double-click selection for hierarchical and scheme-less URLs, path locations, and compound identifiers while preserving direct punctuation selection and Unicode word behavior.

Semantic boundaries now span connected soft-wrapped rows and exclude surrounding prose prefixes and suffixes. Focused black-box coverage exercises URI components, compound prefixes, punctuation, Unicode wide cells, and wrap boundaries.

Fixes https://github.com/pg83/shitty/issues/17
