### PR TITLE
Keep scrollback on modifier-only key presses

### DIFF
--- a/tests/test_scrollback.py
+++ b/tests/test_scrollback.py
@@ -47,6 +47,60 @@ class ScrollbackTest(unittest.TestCase):
             self.assertEqual(after.view_offset, 2)
             self.assertEqual(after.lines, ["one     ", "two     ", "three   "])
 
+    def test_modifier_only_keys_do_not_exit_scrollback(self):
+        modifiers = (
+            (340, 1),
+            (341, 2),
+            (342, 4),
+            (343, 8),
+            (344, 1),
+            (345, 2),
+            (346, 4),
+            (347, 8),
+        )
+        for key, mask in modifiers:
+            with self.subTest(key=key):
+                with Shitty(columns=8, rows=3, save_lines=8) as terminal:
+                    terminal.write(b"one\r\ntwo\r\nthree\r\nfour")
+                    terminal.page_up()
+
+                    terminal.frontend_key_event(key, 1, modifiers=mask)
+                    terminal.frontend_key_event(key, 0)
+
+                    self.assertEqual(terminal.snapshot().view_offset, 1)
+                    self.assertEqual(terminal.read_input(), b"")
+
+        with Shitty(columns=8, rows=3, save_lines=8) as terminal:
+            terminal.write(b"one\r\ntwo\r\nthree\r\nfour")
+            terminal.page_up()
+
+            terminal.frontend_text_event("x")
+
+            self.assertEqual(terminal.snapshot().view_offset, 0)
+            self.assertEqual(terminal.read_input(), b"x")
+
+        with Shitty(columns=8, rows=3, save_lines=8) as terminal:
+            terminal.write(b"one\r\ntwo\r\nthree\r\nfour\x1b[>2u")
+            terminal.page_up()
+
+            terminal.frontend_key_event(340, 1, modifiers=1)
+            terminal.frontend_key_event(340, 0)
+
+            self.assertEqual(terminal.snapshot().view_offset, 1)
+            self.assertEqual(terminal.read_input(), b"")
+
+        with Shitty(columns=8, rows=3, save_lines=8) as terminal:
+            terminal.write(b"one\r\ntwo\r\nthree\r\nfour\x1b[>10u")
+            terminal.page_up()
+
+            terminal.frontend_key_event(340, 1, modifiers=1)
+
+            self.assertEqual(terminal.snapshot().view_offset, 0)
+            self.assertEqual(
+                terminal.read_input(),
+                b"\x1b[57441;2:1u",
+            )
+
     def test_alternate_screen_does_not_keep_scrollback(self):
         with Shitty(columns=8, rows=3, save_lines=8) as terminal:
             terminal.write(

--- a/vterm.cpp
+++ b/vterm.cpp
@@ -6942,6 +6942,9 @@ void VtermImpl::compactPtyOutput() {
 }
 
 int VtermImpl::writePty(const u8* ucstr, size_t len, bool userInput) {
+    if (len == 0) {
+        return 0;
+    }
     if (userInput && keyboardLocked) {
         return len;
     }


### PR DESCRIPTION
Modifier-only keys in the legacy keyboard path resolve to an empty PTY sequence. The byte-write path nevertheless treated that empty sequence as user input and returned the viewport to the live screen.

This change makes zero-length PTY writes no-ops before applying user-input side effects. Regression coverage exercises all left and right frontend modifiers, press and release events, normal text input, and Kitty modes that either suppress or report modifier keys.

Fixes https://github.com/pg83/shitty/issues/21