### PR TITLE
Scroll selections at viewport edges

### DIFF
--- a/test_mode.cpp
+++ b/test_mode.cpp
@@ -464,6 +464,7 @@ namespace {
         void setHasFocus(bool focused);
         bool expireSynchronizedOutput(bool force = false);
         bool advanceAnimation(bool force = false);
+        bool advanceSelectionAutoscroll();
 
         Vterm& terminal;
         TestApi& testApi;
@@ -1169,6 +1170,12 @@ bool TestTerminal::expireSynchronizedOutput(bool force) {
 
 bool TestTerminal::advanceAnimation(bool force) {
     const bool result = terminal.advanceAnimation(force);
+    update();
+    return result;
+}
+
+bool TestTerminal::advanceSelectionAutoscroll() {
+    const bool result = testApi.advanceSelectionAutoscroll();
     update();
     return result;
 }
@@ -1963,6 +1970,9 @@ int runTestMode(Composer& composer, TestModeInput& input, int controlFd, int arg
                 if (terminal.advanceAnimation(true)) {
                     terminal.redraw();
                 }
+                writeAll(controlFd, "OK\n");
+            } else if (line == "SELECTION_AUTOSCROLL_TICK") {
+                terminal.advanceSelectionAutoscroll();
                 writeAll(controlFd, "OK\n");
             } else if (line.compare(0, 13, "SELECT_START ") == 0 || line.compare(0, 14, "SELECT_UPDATE ") == 0) {
                 const bool start = line.compare(0, 13, "SELECT_START ") == 0;

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -553,6 +553,9 @@ class Shitty:
     def blink_tick(self):
         self.command("BLINK_TICK")
 
+    def selection_autoscroll_tick(self):
+        self.command("SELECTION_AUTOSCROLL_TICK")
+
     def select_start(self, column, row):
         self.command(f"SELECT_START {column} {row}")
 

--- a/tests/test_selection_autoscroll.py
+++ b/tests/test_selection_autoscroll.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2026 Shitty team
+# MIT licensed
+# See the file LICENSE.MIT for the full license.
+
+import unittest
+
+from harness import Shitty
+
+
+def numbered_lines(count):
+    return b"\r\n".join(str(line).encode() for line in range(1, count + 1))
+
+
+class SelectionAutoscrollTest(unittest.TestCase):
+    def test_top_edge_scrolls_to_history_limit_and_extends_selection(self):
+        with Shitty(columns=8, rows=4, save_lines=20) as terminal:
+            terminal.write(numbered_lines(10))
+            terminal.button(0, True, x=4, y=5)
+            terminal.pointer(x=2, y=2)
+
+            self.assertEqual(terminal.snapshot().view_offset, 0)
+            terminal.selection_autoscroll_tick()
+            first = terminal.snapshot()
+            self.assertEqual(first.view_offset, 1)
+            self.assertEqual(first.selection, (0, 0, 2, 4))
+
+            for expected_offset in range(2, 7):
+                terminal.selection_autoscroll_tick()
+                self.assertEqual(
+                    terminal.snapshot().view_offset, expected_offset
+                )
+
+            terminal.selection_autoscroll_tick()
+            self.assertEqual(terminal.snapshot().view_offset, 6)
+            self.assertEqual(
+                terminal.button(0, False, x=2, y=2),
+                numbered_lines(10).replace(b"\r", b""),
+            )
+
+    def test_bottom_edge_scrolls_to_live_screen_and_extends_selection(self):
+        with Shitty(columns=8, rows=4, save_lines=20) as terminal:
+            terminal.write(numbered_lines(10))
+            terminal.wheel_up(3)
+            terminal.button(0, True, x=2, y=2)
+            terminal.pointer(x=4, y=5)
+
+            for expected_offset in (2, 1, 0):
+                terminal.selection_autoscroll_tick()
+                self.assertEqual(
+                    terminal.snapshot().view_offset, expected_offset
+                )
+
+            terminal.selection_autoscroll_tick()
+            snapshot = terminal.snapshot()
+            self.assertEqual(snapshot.view_offset, 0)
+            self.assertEqual(snapshot.selection, (0, -3, 2, 3))
+            self.assertEqual(
+                terminal.button(0, False, x=4, y=5),
+                numbered_lines(10)[9:].replace(b"\r", b""),
+            )
+
+    def test_application_mouse_protocol_does_not_autoscroll(self):
+        with Shitty(columns=8, rows=4, save_lines=20) as terminal:
+            terminal.write(numbered_lines(10))
+            terminal.wheel_up(3)
+            terminal.write(b"\x1b[?1000h\x1b[?1006h")
+            terminal.button(0, True, x=2, y=2)
+            terminal.pointer(x=4, y=5)
+
+            terminal.selection_autoscroll_tick()
+
+            self.assertEqual(terminal.snapshot().view_offset, 3)
+            terminal.button(0, False, x=4, y=5)
+
+    def test_shift_override_autoscrolls_local_selection(self):
+        with Shitty(columns=8, rows=4, save_lines=20) as terminal:
+            terminal.write(numbered_lines(10))
+            terminal.wheel_up(3)
+            terminal.write(b"\x1b[?1000h\x1b[?1006h")
+            terminal.button(0, True, x=2, y=2, modifiers=1)
+            terminal.pointer(x=4, y=5, modifiers=1)
+
+            terminal.selection_autoscroll_tick()
+
+            self.assertEqual(terminal.snapshot().view_offset, 2)
+            self.assertEqual(terminal.read_input(), b"")
+            terminal.button(0, False, x=4, y=5, modifiers=1)
+
+    def test_alternate_drag_does_not_autoscroll_primary_after_return(self):
+        with Shitty(columns=8, rows=4, save_lines=20) as terminal:
+            terminal.write(numbered_lines(10))
+            terminal.wheel_up(3)
+            terminal.select_start(0, 0)
+            terminal.select_update(2, 1)
+            self.assertNotEqual(terminal.select_finish(), b"")
+            primary = terminal.snapshot()
+
+            terminal.write(b"\x1b[?1049h")
+            terminal.button(0, True, x=4, y=5)
+            terminal.pointer(x=2, y=2)
+            terminal.write(b"\x1b[?1049l")
+            terminal.selection_autoscroll_tick()
+
+            current = terminal.snapshot()
+            self.assertEqual(current.view_offset, primary.view_offset)
+            self.assertEqual(current.selection, primary.selection)
+            self.assertEqual(terminal.read_input(), b"")
+
+    def test_primary_drag_does_not_survive_alternate_round_trip(self):
+        with Shitty(columns=8, rows=4, save_lines=20) as terminal:
+            terminal.write(numbered_lines(10))
+            terminal.button(0, True, x=4, y=5)
+            terminal.pointer(x=2, y=2)
+            primary = terminal.snapshot()
+
+            terminal.write(b"\x1b[?1049h\x1b[?1049l")
+            terminal.selection_autoscroll_tick()
+
+            current = terminal.snapshot()
+            self.assertEqual(current.view_offset, primary.view_offset)
+            self.assertEqual(current.selection, primary.selection)
+            self.assertEqual(terminal.read_input(), b"")
+
+    def test_autoscroll_stops_when_drag_is_no_longer_active_at_edge(self):
+        for event in ("away", "release", "leave", "focus-loss"):
+            with self.subTest(event=event):
+                with Shitty(columns=8, rows=4, save_lines=20) as terminal:
+                    terminal.write(numbered_lines(10))
+                    terminal.button(0, True, x=4, y=5)
+                    terminal.pointer(x=2, y=2)
+
+                    if event == "away":
+                        terminal.pointer(x=2, y=3)
+                    elif event == "release":
+                        terminal.button(0, False, x=2, y=2)
+                    elif event == "leave":
+                        terminal.pointer_presence(False)
+                    else:
+                        terminal.focus(False)
+
+                    terminal.selection_autoscroll_tick()
+
+                    self.assertEqual(terminal.snapshot().view_offset, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vterm.cpp
+++ b/vterm.cpp
@@ -87,6 +87,7 @@ void MouseTrackingState::setEncoding(MouseTrackingEnc value) {
 
 namespace {
     constexpr size_t ptyProtocolHighWater = 1024 * 1024;
+    constexpr u64 selectionAutoscrollInterval = 50'000;
 
     StringView stringView(const std::string& value) {
         return StringView((const u8*)(value.data()), value.size());
@@ -138,6 +139,11 @@ namespace {
         void refreshHyperlinkAndRedraw();
         void updatePointer(int pixelX, int pixelY, u16 modifiers);
         void updatePointerModifiers(const KeyInput& input);
+        int currentSelectionAutoscrollDirection() const;
+        void updateSelectionAutoscroll();
+        void stopSelectionAutoscroll();
+        void armTimeout();
+        bool advanceSelectionAutoscroll(bool force);
         ScreenHyperlink resolveLink(int pixelX, int pixelY);
         bool paste(bool primary);
 
@@ -164,6 +170,8 @@ namespace {
         bool pointerPresent = false;
         bool pointerPositionKnown = false;
         bool pointerFocused = true;
+        int selectionAutoscrollDirection = 0;
+        u64 selectionAutoscrollDeadline = 0;
         Buffer schemeScratch;
         bool locallyConsumedKeys[(unsigned)(InputKey::Count) + 128]{};
     };
@@ -943,6 +951,7 @@ namespace {
         void selectionUpdate(int pixelX, int pixelY) override;
         VtermTextResult selectionFinish() override;
         void selectionRectangular() override;
+        bool advanceSelectionAutoscroll() override;
         void paste(StringView text) override;
         StringView hyperlinkAt(int pixelX, int pixelY) override;
 
@@ -1270,6 +1279,77 @@ void VtermInput::updatePointerModifiers(const KeyInput& input) {
     refreshHyperlinkAndRedraw();
 }
 
+int VtermInput::currentSelectionAutoscrollDirection() const {
+    const unsigned selectionButtons = (1u << (unsigned)(PointerButton::Primary)) | (1u << (unsigned)(PointerButton::Secondary));
+    if (!mouse.selectionOngoing() || !(mouse.buttons() & selectionButtons) || terminal->cf->getSelection().null() || !pointerFocused || !pointerPresent || !pointerPositionKnown) {
+        return 0;
+    }
+    const int top = opts.border;
+    const int bottom = std::max(top, (int)(terminal->composer.pixelHeight) - opts.border - 1);
+    if (pointerY <= top) {
+        return -1;
+    }
+    if (pointerY >= bottom) {
+        return 1;
+    }
+    return 0;
+}
+
+void VtermInput::updateSelectionAutoscroll() {
+    const int direction = currentSelectionAutoscrollDirection();
+    if (direction == 0) {
+        stopSelectionAutoscroll();
+        return;
+    }
+    if (direction == selectionAutoscrollDirection && selectionAutoscrollDeadline != 0) {
+        return;
+    }
+    selectionAutoscrollDirection = direction;
+    selectionAutoscrollDeadline = monotonicNowUs() + selectionAutoscrollInterval;
+    armTimeout();
+}
+
+void VtermInput::stopSelectionAutoscroll() {
+    selectionAutoscrollDirection = 0;
+    selectionAutoscrollDeadline = 0;
+}
+
+void VtermInput::armTimeout() {
+    if (selectionAutoscrollDeadline != 0) {
+        terminal->composer.poller->deadline(selectionAutoscrollDeadline);
+    }
+}
+
+bool VtermInput::advanceSelectionAutoscroll(bool force) {
+    if (selectionAutoscrollDeadline == 0) {
+        return false;
+    }
+    const u64 now = monotonicNowUs();
+    if (!force && now < selectionAutoscrollDeadline) {
+        return false;
+    }
+    const int direction = currentSelectionAutoscrollDirection();
+    if (direction == 0 || direction != selectionAutoscrollDirection) {
+        stopSelectionAutoscroll();
+        return false;
+    }
+    const u32 previousOffset = terminal->cf->getViewOffset();
+    if (direction < 0) {
+        terminal->cf->pageUp(1);
+    } else {
+        terminal->cf->pageDown(1);
+    }
+    if (terminal->cf->getViewOffset() == previousOffset) {
+        stopSelectionAutoscroll();
+        return false;
+    }
+    terminal->refreshBlinkingText();
+    terminal->selectUpdate(pointerX, pointerY);
+    selectionAutoscrollDeadline = now + selectionAutoscrollInterval;
+    armTimeout();
+    return true;
+}
+
 void VtermInput::flush() {
     if (!pendingTextKey.active) {
         return;
@@ -1465,6 +1545,9 @@ bool VtermInput::pointerButton(const PointerButtonInput& input) {
     updatePointer(input.pixelX, input.pixelY, input.modifiers);
     const int button = (int)(input.button);
     mouse.updateButton(button, input.pressed);
+    if (!input.pressed && (input.button == PointerButton::Primary || input.button == PointerButton::Secondary)) {
+        stopSelectionAutoscroll();
+    }
     const MouseTrackingState tracking = terminal->mouseTrk;
     const int protocolButton = mouseTerminalButton(button);
     u16 locatorColumn = 1;
@@ -1527,6 +1610,7 @@ bool VtermInput::pointerMotion(const PointerMotionInput& input) {
     terminal->setLocatorPosition(locatorColumn, locatorRow, std::max(1, input.pixelX + 1), std::max(1, input.pixelY + 1), 0);
     const MouseTrackingState tracking = terminal->mouseTrk;
     if (mouse.protocolActive(input.modifiers, tracking.mode)) {
+        stopSelectionAutoscroll();
         if (tracking.mode == MouseTrackingMode::VT200_ButtonEvent && !mouse.primaryButtonPressed()) {
             return true;
         }
@@ -1541,6 +1625,9 @@ bool VtermInput::pointerMotion(const PointerMotionInput& input) {
         }
     } else if (mouse.buttons() & ((1u << (unsigned)(PointerButton::Primary)) | (1u << (unsigned)(PointerButton::Secondary)))) {
         terminal->selectionUpdate(input.pixelX, input.pixelY);
+        updateSelectionAutoscroll();
+    } else {
+        stopSelectionAutoscroll();
     }
     return true;
 }
@@ -1578,6 +1665,7 @@ void VtermInput::focus(bool focused) {
         hyperlinkClick = false;
         mouse.clearButtons();
         mouse.endSelection();
+        stopSelectionAutoscroll();
         suppressedTextInputs = 0;
         suppressRepeatedTextInput = false;
         pendingTextKey.active = false;
@@ -1592,6 +1680,7 @@ void VtermInput::pointerPresence(bool present) {
     pointerPresent = present;
     if (!present) {
         pointerPositionKnown = false;
+        stopSelectionAutoscroll();
     }
     refreshHyperlinkAndRedraw();
 }
@@ -2071,6 +2160,10 @@ void TestApiImpl::selectionRectangular() {
     vterm->selectionRectangular();
 }
 
+bool TestApiImpl::advanceSelectionAutoscroll() {
+    return vterm->input.advanceSelectionAutoscroll(true);
+}
+
 void TestApiImpl::paste(StringView text) {
     vterm->paste(text);
 }
@@ -2107,10 +2200,12 @@ void VtermImpl::armTimeout() {
     if (animationActive()) {
         composer.poller->deadline(nextBlink);
     }
+    input.armTimeout();
 }
 
 void VtermImpl::timeout() {
     expireSynchronizedOutput(false);
+    input.advanceSelectionAutoscroll(false);
     if (advanceAnimation(false)) {
         expose();
     }
@@ -2508,6 +2603,9 @@ void VtermImpl::switchColMode(ColMode colMode_) {
 }
 
 void VtermImpl::switchScreenBufferMode(bool altScreenBufferMode_, bool clearAlternate) {
+    if (altScreenBufferMode != altScreenBufferMode_ || (altScreenBufferMode_ && clearAlternate)) {
+        input.stopSelectionAutoscroll();
+    }
     if (altScreenBufferMode == altScreenBufferMode_) {
         if (clearAlternate) {
             if (altScreenBufferMode_) {

--- a/vterm_test.h
+++ b/vterm_test.h
@@ -51,6 +51,7 @@ struct TestApi {
     virtual void selectionUpdate(int pixelX, int pixelY) = 0;
     virtual VtermTextResult selectionFinish() = 0;
     virtual void selectionRectangular() = 0;
+    virtual bool advanceSelectionAutoscroll() = 0;
     virtual void paste(stl::StringView text) = 0;
     virtual stl::StringView hyperlinkAt(int pixelX, int pixelY) = 0;
 };


### PR DESCRIPTION
Selection drags currently stop at the visible top or bottom row even when scrollback remains available.

This change advances the viewport one row per event-loop tick while a local selection is held at an edge, remaps the selection endpoint after each successful page operation, and stops at history/live bounds or when local ownership ends. Pending autoscroll is cancelled across active screen-buffer transitions so an alternate-screen drag cannot mutate the primary screen.

Deterministic headless coverage exercises both directions, bounds, mouse-protocol ownership, cancellation paths, and primary/alternate isolation.

Fixes https://github.com/pg83/shitty/issues/19
