### PR TITLE
Bound PTY drains and queued terminal replies

### DIFF
--- a/pty.cpp
+++ b/pty.cpp
@@ -35,6 +35,7 @@
 
 #include <std/mem/obj_pool.h>
 #include <std/str/view.h>
+#include <std/sys/crt.h>
 
 #define _POSIX_C_SOURCE 200809L
 
@@ -232,11 +233,13 @@ bool PtyImpl::flushOutput() {
 }
 
 bool PtyImpl::readInput() {
-    constexpr size_t maxDrainBytes = 20 * 1024 * 1024;
+    constexpr size_t maxDrainBytes = 256 * 1024;
+    constexpr u64 maxDrainMicroseconds = 4'000;
     Vterm* const vterm = composer_.vterm;
     u8 buffer[8192];
     size_t drained = 0;
-    while (drained < maxDrainBytes) {
+    const u64 deadline = monotonicNowUs() + maxDrainMicroseconds;
+    while (drained < maxDrainBytes && monotonicNowUs() < deadline) {
         const ssize_t count = read(buffer, sizeof(buffer));
         if (count > 0) {
             vterm->feedPty(StringView(buffer, count));

--- a/test_mode.cpp
+++ b/test_mode.cpp
@@ -35,6 +35,7 @@
 #include <std/lib/buffer.h>
 #include <std/lib/vector.h>
 #include <std/mem/obj_pool.h>
+#include <std/sys/crt.h>
 #include <std/sys/throw.h>
 
 #include <algorithm>
@@ -1003,11 +1004,13 @@ u64 TestTerminal::droppedPtyResponses() {
 }
 
 bool TestTerminal::readPty() {
-    constexpr size_t maxDrainBytes = 20 * 1024 * 1024;
+    constexpr size_t maxDrainBytes = 256 * 1024;
+    constexpr u64 maxDrainMicroseconds = 4'000;
     u8 buffer[8192];
     size_t drained = 0;
     bool finished = false;
-    while (drained < maxDrainBytes) {
+    const u64 deadline = monotonicNowUs() + maxDrainMicroseconds;
+    while (drained < maxDrainBytes && monotonicNowUs() < deadline) {
         const ssize_t count = pty.read(buffer, sizeof(buffer));
         if (count > 0) {
             terminal.feedPty(StringView(buffer, count));

--- a/tests/test_pty.py
+++ b/tests/test_pty.py
@@ -11,15 +11,14 @@ from harness import Shitty
 
 
 class PtyTest(unittest.TestCase):
-    def test_twenty_mibibyte_drain_limit_yields_with_input_remaining(self):
-        limit = 20 * 1024 * 1024
+    def test_drain_yields_before_one_mibibyte_of_continuous_input(self):
+        continuous_input = 1024 * 1024
         with Shitty(columns=8, rows=2) as terminal:
-            terminal.script_pty_repeat(0, limit + 1, eof=True)
+            terminal.script_pty_repeat(0, continuous_input, eof=True)
             self.assertFalse(terminal.read_pty())
-            self.assertEqual(terminal.pending_scripted_pty_read_bytes(), 1)
-
-            self.assertTrue(terminal.read_pty())
-            self.assertEqual(terminal.pending_scripted_pty_read_bytes(), 0)
+            remaining = terminal.pending_scripted_pty_read_bytes()
+            self.assertGreater(remaining, 0)
+            self.assertLess(remaining, continuous_input)
 
     def test_eof_finishes_even_before_the_first_payload(self):
         with Shitty(columns=8, rows=2) as terminal:

--- a/tests/test_pty_output.py
+++ b/tests/test_pty_output.py
@@ -9,7 +9,7 @@ from harness import Shitty
 
 
 class PtyOutputTest(unittest.TestCase):
-    protocol_high_water = 1024 * 1024
+    protocol_high_water = 4096
 
     def test_simultaneous_read_and_write_flushes_older_bytes_before_reply(self):
         with Shitty(columns=8, rows=2) as terminal:

--- a/vterm.cpp
+++ b/vterm.cpp
@@ -86,7 +86,7 @@ void MouseTrackingState::setEncoding(MouseTrackingEnc value) {
 }
 
 namespace {
-    constexpr size_t ptyProtocolHighWater = 1024 * 1024;
+    constexpr size_t ptyProtocolHighWater = 4096;
 
     StringView stringView(const std::string& value) {
         return StringView((const u8*)(value.data()), value.size());

--- a/window.cpp
+++ b/window.cpp
@@ -196,7 +196,7 @@ void NativeWindowImpl::initialize() {
         }
     );
     const plt::WindowInfo current = native->info();
-    if (isfinite(current.contentScale) && current.contentScale > 0.0f) {
+    if (std::isfinite(current.contentScale) && current.contentScale > 0.0f) {
         composer.setContentScale(current.contentScale);
     }
 }
@@ -437,7 +437,7 @@ void NativeWindowImpl::close() {
 }
 
 void NativeWindowImpl::resized(const plt::WindowInfo& current) {
-    if (isfinite(current.contentScale) && current.contentScale > 0.0f) {
+    if (std::isfinite(current.contentScale) && current.contentScale > 0.0f) {
         composer.setContentScale(current.contentScale);
     }
     composer.resize((u16)(min(current.width, (u32)(UINT16_MAX))), (u16)(min(current.height, (u32)(UINT16_MAX))));
@@ -750,7 +750,7 @@ void TestInputTranslator::sendText(Composer& composer, u32 codepoint, int rawMod
 
 void TestInputTranslator::contentScale(Composer& composer, float xScale, float yScale) {
     const float scale = max(xScale, yScale);
-    if (isfinite(scale) && scale > 0.0f) {
+    if (std::isfinite(scale) && scale > 0.0f) {
         composer.setContentScale(scale);
     }
 }


### PR DESCRIPTION
## Summary

* stop one PTY readiness drain after 256 KiB or 4 ms, whichever comes first
* retain at most 4 KiB of terminal-generated replies when the child is not
  reading them; keyboard and paste input remain exempt
* enforce both scheduling contracts in deterministic PTY regressions
* qualify three `std::isfinite` calls that fail to compile with Clang 21

## Root causes

Two independent stages contributed to the reported behavior.

First, `PtyImpl::readInput()` previously parsed up to 20 MiB synchronously in
one platform readiness callback. Random bytes frequently miss the ASCII and
valid UTF-8 bulk paths, so one callback occupied the event-loop thread for
roughly 400 ms on the affected host. The byte/time quantum bounds that
presentation latency.

Second, random output contains terminal queries. When the foreground producer
does not read the replies, the kernel PTY input queue applies backpressure and
`VtermImpl::writePty()` retains replies in `ptyBuffer`. The previous 1 MiB
limit allowed that stream to survive until the producer exited. The resumed
interactive shell then processed it as keyboard input.

An exact manual-lifecycle capture found:

```text
head  already exited
st    blocked in poll()
zsh   runnable in zle-line-pre-redraw / zsh-syntax-highlighting
```

With syntax highlighting length-limited, the same reply stream became visible
at the prompt and `zsh` used 96.7% of one core while `st` remained in
`poll()`. Visible fragments matched the primary device-attribute response.

Isolated replay of that response format measured:

```text
queued reply bytes   elapsed in interactive zsh
4 KiB                0.061 s
16 KiB               0.843 s
64 KiB               12.839 s
256 KiB              >15 s
```

The new 4 KiB bound limits inherited terminal replies to a short, measured
recovery interval while preserving all user-originated input.

## Reproduction and verification

Before the drain change, its regression consumed the complete scripted 1 MiB
stream in one readiness dispatch.

Before the reply-bound change, the updated query-stream regression failed for
the intended reason:

```text
AssertionError: 4124 != 4096
```

After both changes:

* PTY-output and PTY-lifecycle modules: 25/25 pass
* C++ unit tests and Python integration suite: 814/814 pass

The current upstream Nix build required build-only Wayland/xkb and tablet
protocol link inputs. Two build-metadata fixtures also required substituting
the NixOS `touch` path for their hard-coded `/usr/bin/touch`; neither
environment compatibility adjustment is included in this branch.
