### PR TITLE
Fix Ctrl+letter key codes under the kitty keyboard protocol on macOS

### DIFF
--- a/third_party/plt/build.py
+++ b/third_party/plt/build.py
@@ -143,17 +143,20 @@ libplt = library(
 )
 
 if build.target == build.host:
+    plt_unit_test_sources = [
+        "$(S)/tests/test_ut.cpp",
+        "$(S)/drop_ut.cpp",
+        "$(S)/fiber_ut.cpp",
+        "$(S)/mutex_ut.cpp",
+        "$(S)/platform_headless_ut.cpp",
+        "$(S)/pointer_grab_ut.cpp",
+    ]
+    if system == "Darwin":
+        plt_unit_test_sources.append("$(S)/platform_cocoa_ut.mm")
     plt_unit_tests = program(
         name="plt_unit_tests",
         output="$(B)/plt_unit_tests",
-        srcs=[
-            "$(S)/tests/test_ut.cpp",
-            "$(S)/drop_ut.cpp",
-            "$(S)/fiber_ut.cpp",
-            "$(S)/mutex_ut.cpp",
-            "$(S)/platform_headless_ut.cpp",
-            "$(S)/pointer_grab_ut.cpp",
-        ],
+        srcs=plt_unit_test_sources,
         deps=[libplt, libstd],
     )
 

--- a/third_party/plt/platform_cocoa.h
+++ b/third_party/plt/platform_cocoa.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#ifdef __OBJC__
+#include "input.h"
+
+@class NSEvent;
+#endif
+
 namespace stl {
     class ObjPool;
 }
@@ -8,4 +14,10 @@ namespace plt {
     struct Platform;
 
     Platform* createCocoaPlatform(stl::ObjPool& owner);
+
+#ifdef __OBJC__
+    // The pure NSEvent -> KeyInput translation behind the window's key
+    // handler, exposed so unit tests can drive it with synthesized events.
+    KeyInput keyInputFromEvent(NSEvent* event, bool pressed);
+#endif
 }

--- a/third_party/plt/platform_cocoa.mm
+++ b/third_party/plt/platform_cocoa.mm
@@ -545,9 +545,6 @@ namespace {
         void button(NSEvent* event, bool pressed);
         void scroll(NSEvent* event);
         void pointerPresence(bool present);
-        u16 modifiers(NSEventModifierFlags flags) const;
-        InputKey inputKey(NSEvent* event) const;
-        u32 firstCodepoint(NSString* string) const;
         void emitText(NSString* string, u16 modifiers);
         NSPoint pointerPosition(NSEvent* event) const;
         void writePasteboard(NSPasteboard* pasteboard, StringView content);
@@ -1468,7 +1465,7 @@ void WindowImpl::focused(bool value) {
     }
 }
 
-u16 WindowImpl::modifiers(NSEventModifierFlags flags) const {
+static u16 modifiers(NSEventModifierFlags flags) {
     u16 result = 0;
     if (flags & NSEventModifierFlagShift) {
         result |= InputShift;
@@ -1488,7 +1485,7 @@ u16 WindowImpl::modifiers(NSEventModifierFlags flags) const {
     return result;
 }
 
-u32 WindowImpl::firstCodepoint(NSString* string) const {
+static u32 firstCodepoint(NSString* string) {
     if (string.length == 0) {
         return 0;
     }
@@ -1499,7 +1496,7 @@ u32 WindowImpl::firstCodepoint(NSString* string) const {
     return first;
 }
 
-InputKey WindowImpl::inputKey(NSEvent* event) const {
+static InputKey inputKey(NSEvent* event) {
     switch (event.keyCode) {
         case kVK_ANSI_Keypad0:
             return InputKey::Keypad0;
@@ -1609,27 +1606,7 @@ void WindowImpl::key(NSEvent* event, bool pressed) {
     if (input == nullptr) {
         return;
     }
-    const InputAction action = !pressed ? InputAction::Release : (event.isARepeat ? InputAction::Repeat : InputAction::Press);
-    u16 mods = modifiers(event.modifierFlags);
-    const InputKey key = inputKey(event);
-    if (key >= InputKey::Keypad0 && key <= InputKey::KeypadDecimal) {
-        mods |= InputNumLock;
-    }
-    const u32 layout = firstCodepoint(event.characters);
-    u32 base = firstCodepoint(event.charactersIgnoringModifiers);
-    if (key == InputKey::Printable && base >= 0x80) {
-        const u32 ascii = asciiBaseCodepoint(event);
-        if (ascii >= 0x20 && ascii < 0x7f) {
-            base = ascii;
-        }
-    }
-    input->key({
-        .key = key,
-        .action = action,
-        .modifiers = mods,
-        .layoutCodepoint = layout,
-        .baseCodepoint = base,
-    });
+    input->key(keyInputFromEvent(event, pressed));
 }
 
 void WindowImpl::flushInput() {
@@ -1821,7 +1798,7 @@ void cocoaKeyImpl(void* owner, NSEvent* event, bool pressed) {
 
 void cocoaTextImpl(void* owner, NSString* text, NSEventModifierFlags flags) {
     WindowImpl* const window = (WindowImpl*)(owner);
-    window->emitText(text, window->modifiers(flags));
+    window->emitText(text, modifiers(flags));
 }
 
 void cocoaFlushInputImpl(void* owner) {
@@ -1877,6 +1854,37 @@ void cocoaWakeReady(CFMachPortRef, void*, CFIndex, void* owner) {
 
 void cocoaTimerReady(CFRunLoopTimerRef, void* owner) {
     ((PollerImpl*)(owner))->dispatchTimers();
+}
+
+KeyInput plt::keyInputFromEvent(NSEvent* event, bool pressed) {
+    const InputAction action = !pressed ? InputAction::Release : (event.isARepeat ? InputAction::Repeat : InputAction::Press);
+    u16 mods = modifiers(event.modifierFlags);
+    const InputKey key = inputKey(event);
+    if (key >= InputKey::Keypad0 && key <= InputKey::KeypadDecimal) {
+        mods |= InputNumLock;
+    }
+    u32 layout = firstCodepoint(event.characters);
+    u32 base = firstCodepoint(event.charactersIgnoringModifiers);
+    if (key == InputKey::Printable && base >= 0x80) {
+        const u32 ascii = asciiBaseCodepoint(event);
+        if (ascii >= 0x20 && ascii < 0x7f) {
+            base = ascii;
+        }
+    }
+    // Cocoa folds Control into characters: Ctrl+B reports STX, where xkbcommon
+    // reports 'b'. A C0 control is never a layout key, and the kitty key field
+    // needs the layout one - reporting 2 instead of 98 kills every multiplexer
+    // prefix. The named keys carry their own codes, so only printables recover.
+    if (key == InputKey::Printable && layout < 0x20 && base >= 0x20) {
+        layout = base;
+    }
+    return {
+        .key = key,
+        .action = action,
+        .modifiers = mods,
+        .layoutCodepoint = layout,
+        .baseCodepoint = base,
+    };
 }
 
 Platform* plt::createCocoaPlatform(ObjPool& owner) {

--- a/third_party/plt/platform_cocoa_ut.mm
+++ b/third_party/plt/platform_cocoa_ut.mm
@@ -1,0 +1,83 @@
+#include "platform_cocoa.h"
+
+#include <std/tst/ut.h>
+
+#import <AppKit/AppKit.h>
+#import <Carbon/Carbon.h>
+
+using namespace plt;
+using namespace stl;
+
+namespace {
+    NSEvent* keyEvent(NSString* characters, NSString* base, NSEventModifierFlags flags, unsigned short keyCode) {
+        return [NSEvent keyEventWithType:NSEventTypeKeyDown
+                                location:NSMakePoint(0, 0)
+                           modifierFlags:flags
+                               timestamp:0
+                            windowNumber:0
+                                 context:nil
+                              characters:characters
+             charactersIgnoringModifiers:base
+                               isARepeat:NO
+                                 keyCode:keyCode];
+    }
+}
+
+STD_TEST_SUITE(PlatformCocoaKey) {
+    // Cocoa folds Control into characters: Ctrl+B delivers STX there, where
+    // xkbcommon reports 'b'. The layout codepoint feeds the kitty-protocol
+    // key field, and a C0 control is never a valid key - reporting 2 instead
+    // of 98 kills every terminal-multiplexer prefix.
+    STD_TEST(ControlFoldedLetterRecoversTheLayoutKey) {
+        @autoreleasepool {
+            const KeyInput input = keyInputFromEvent(keyEvent(@"\x02", @"b", NSEventModifierFlagControl, kVK_ANSI_B), true);
+            STD_INSIST(input.key == InputKey::Printable);
+            STD_INSIST((input.modifiers & InputControl) != 0);
+            STD_INSIST(input.layoutCodepoint == 'b');
+            STD_INSIST(input.baseCodepoint == 'b');
+        }
+    }
+
+    STD_TEST(ControlFoldedPunctuationRecoversTheLayoutKey) {
+        @autoreleasepool {
+            // Ctrl+[ folds to ESC, the same codepoint the real Escape key
+            // carries; only the Printable key may be rewritten.
+            const KeyInput input = keyInputFromEvent(keyEvent(@"\x1b", @"[", NSEventModifierFlagControl, kVK_ANSI_LeftBracket), true);
+            STD_INSIST(input.key == InputKey::Printable);
+            STD_INSIST(input.layoutCodepoint == '[');
+        }
+    }
+
+    STD_TEST(NamedKeysKeepTheirControlCodepoints) {
+        @autoreleasepool {
+            const KeyInput escape = keyInputFromEvent(keyEvent(@"\x1b", @"\x1b", 0, kVK_Escape), true);
+            STD_INSIST(escape.key == InputKey::Escape);
+            STD_INSIST(escape.layoutCodepoint == 0x1b);
+
+            const KeyInput enter = keyInputFromEvent(keyEvent(@"\r", @"\r", 0, kVK_Return), true);
+            STD_INSIST(enter.key == InputKey::Enter);
+            STD_INSIST(enter.layoutCodepoint == '\r');
+
+            const KeyInput tab = keyInputFromEvent(keyEvent(@"\t", @"\t", 0, kVK_Tab), true);
+            STD_INSIST(tab.key == InputKey::Tab);
+            STD_INSIST(tab.layoutCodepoint == '\t');
+
+            const KeyInput backspace = keyInputFromEvent(keyEvent(@"\x7f", @"\x7f", 0, kVK_Delete), true);
+            STD_INSIST(backspace.key == InputKey::Backspace);
+            STD_INSIST(backspace.layoutCodepoint == 0x7f);
+        }
+    }
+
+    STD_TEST(ControlFoldedRecoveryUsesTheAsciiBase) {
+        @autoreleasepool {
+            // On a Russian layout Ctrl+B reports STX with CYRILLIC VE as the
+            // base. The recovery must run after the ASCII-capable-layout
+            // correction and pick up whatever base it resolved, never the
+            // folded control.
+            const KeyInput input = keyInputFromEvent(keyEvent(@"\x02", @"в", NSEventModifierFlagControl, kVK_ANSI_B), true);
+            STD_INSIST(input.key == InputKey::Printable);
+            STD_INSIST(input.layoutCodepoint == input.baseCodepoint);
+            STD_INSIST(input.layoutCodepoint >= 0x20);
+        }
+    }
+}


### PR DESCRIPTION
## Symptom

On macOS, with the kitty keyboard protocol enabled by the application, every Ctrl+letter chord is emitted with a C0 control in the CSI-u key field: Ctrl+B sends `\e[2;5u` instead of `\e[98;5u`. Terminal multiplexers (tmux, screen, zellij, herdr) match nothing against key code 2 and silently drop it, so the prefix key appears dead. Legacy encoding is unaffected — it never consults the layout codepoint — which is what confines the breakage to protocol-aware applications. Wayland is unaffected.

## Root cause

The Cocoa backend derives `layoutCodepoint` from `NSEvent.characters`, and Cocoa folds Control into `characters`: Ctrl+B reports U+0002 rather than 'b'. The Wayland backend derives the same field via `xkb_state_key_get_utf32()`, and xkbcommon deliberately performs no control folding — Control is not a level-shifting modifier — so the two backends disagreed on what the field means. `VtermInput::key` prefers a non-zero `layoutCodepoint`, so the correct base key already sitting in `baseCodepoint` was never consulted, and the folded control went out verbatim as the kitty key field, where a C0 control is never a valid key code.

## Fix

Recover the layout key at the source, in the Cocoa backend, so `layoutCodepoint` never carries a folded control and `vterm.cpp` stays platform-agnostic. Two constraints:

- The recovery is guarded on `InputKey::Printable`: the real Escape, Tab, Enter and Backspace keys legitimately carry C0 codepoints and keep them.
- It runs after the existing ASCII-capable-layout correction, so on a non-Latin layout the recovered value is the Latin key, not the native codepoint.

An alternative would be a defensive guard where `vterm.cpp` chooses the primary key, which would also protect future backends at the cost of leaving `layoutCodepoint` semantically wrong on macOS for any other consumer. Happy to rework in that direction if preferred. Likewise, since `third_party/plt` is vendored, I can submit this to the plt project instead if that is the preferred route.

This likely also resolves #16: with a Cyrillic layout the same folding puts the C0 control in the key field, so Crossterm consumers never see the base-layout key that is correctly reported alongside it.

## Tests

The NSEvent → KeyInput translation had no coverage (`test_input` injects `KeyInput` structs downstream of it), so the translation moves behind `plt::keyInputFromEvent` and a new `platform_cocoa_ut.mm` drives it with synthesized NSEvents:

- Ctrl+B recovers layout 'b' — watched fail with key code 2 before the fix
- Ctrl+[ recovers '[' (a folded ESC on a Printable key)
- Escape, Enter, Tab and Backspace keep their C0 codepoints
- a control-folded event with a Cyrillic base recovers whatever ASCII base the existing layout correction resolves, pinning the ordering of the two fixups

All 32 plt unit tests pass on macOS. Verified interactively: `st -e sh -c 'printf "\033[>1u"; cat -v'` prints `^[[98;5u` for Ctrl+B (previously `^[[2;5u`), a herdr session's prefix key works again, and Ctrl+B still sends a raw 0x02 with the protocol disabled.
