### PR TITLE
Attest release artifacts before publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ on:
         required: false
 
 permissions:
+  attestations: write
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -33,8 +35,18 @@ jobs:
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Build and publish
+      - name: Build draft release
         run: |
-          python3 dev/release.py ${{ inputs.tag }} --sha "$GITHUB_SHA" --builder brew --generate-notes
+          python3 dev/release.py ${{ inputs.tag }} --sha "$GITHUB_SHA" --builder brew --generate-notes \
+            --artifacts-directory "$RUNNER_TEMP/release-artifacts" --draft \
+            --tag-file "$RUNNER_TEMP/release-tag"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Attest release artifacts
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: '${{ runner.temp }}/release-artifacts/*.tar.gz'
+      - name: Publish release
+        run: gh release edit "$(cat "$RUNNER_TEMP/release-tag")" --draft=false --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/dev/release.py
+++ b/dev/release.py
@@ -214,6 +214,21 @@ def main() -> int:
         action="store_true",
         help="let GitHub generate the release notes instead of reading stdin",
     )
+    parser.add_argument(
+        "--artifacts-directory",
+        type=Path,
+        help="directory in which to retain the generated release artifacts",
+    )
+    parser.add_argument(
+        "--draft",
+        action="store_true",
+        help="create a draft release instead of publishing it",
+    )
+    parser.add_argument(
+        "--tag-file",
+        type=Path,
+        help="write the resolved tag to this file after creating the release",
+    )
     arguments = parser.parse_args()
 
     if arguments.tag is not None and not re.fullmatch(r"[1-9][0-9]*", arguments.tag):
@@ -253,8 +268,11 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix=f"shitty-release-{arguments.tag}-") as temporary_name:
         temporary = Path(temporary_name)
         checkout = temporary / "checkout"
-        artifacts = temporary / "artifacts"
-        artifacts.mkdir()
+        if arguments.artifacts_directory is None:
+            artifacts = temporary / "artifacts"
+        else:
+            artifacts = arguments.artifacts_directory.resolve()
+        artifacts.mkdir(parents=True)
 
         run(["git", "clone", "--no-checkout", remote, os.fspath(checkout)])
         resolved_sha = run(
@@ -336,9 +354,12 @@ def main() -> int:
                     if arguments.generate_notes
                     else ["--notes-file", os.fspath(notes_file)]
                 ),
+                *(["--draft"] if arguments.draft else []),
             ],
             cwd=checkout,
         )
+        if arguments.tag_file is not None:
+            arguments.tag_file.write_text(f"{arguments.tag}\n")
         print(run(
             [
                 "gh",


### PR DESCRIPTION
Release archives downloaded from GitHub currently have no repository-bound provenance. An attestation lets a user verify that a downloaded archive has the digest recorded by GitHub Actions for this repository and was produced by the expected release workflow. It verifies artifact integrity and build provenance; it does not audit the artifact contents or claim that they are safe.

The release workflow currently removes its temporary artifacts as soon as `dev/release.py` exits, so a later Actions step cannot attest the exact files uploaded to the release.

This retains the two release archives in runner temporary storage, creates the release as a draft, generates GitHub build provenance for both `shitty-<tag>.tar.gz` and `st-darwin-arm64.tar.gz`, and publishes the draft after successful attestation. The new `release.py` options are opt-in; existing local release behavior remains unchanged.

After downloading a release, both published archives can be verified with GitHub CLI:

```sh
tag=<release-tag>
mkdir "shitty-${tag}"
gh release download "${tag}" \
  --repo pg83/shitty \
  --pattern "*.tar.gz" \
  --dir "shitty-${tag}"

for artifact in "shitty-${tag}"/*.tar.gz; do
  gh attestation verify "${artifact}" \
    --repo pg83/shitty \
    --signer-workflow pg83/shitty/.github/workflows/release.yml \
    --source-ref refs/heads/master
done
```

A successful command verifies the archive digest, GitHub-signed provenance, repository identity, signer workflow, and the upstream `master` source ref.