### PR TITLE
Build Ubuntu release packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,62 @@ permissions:
   contents: read
 
 jobs:
+  ubuntu-deb:
+    name: Ubuntu package
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install the Ubuntu toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            binutils \
+            clang \
+            dpkg-dev \
+            file \
+            glslang-tools \
+            libbrotli-dev \
+            libfontconfig-dev \
+            libfreetype-dev \
+            libharfbuzz-dev \
+            librsvg2-bin \
+            libutf8proc-dev \
+            libvulkan-dev \
+            libwayland-dev \
+            libxkbcommon-dev \
+            lintian \
+            pkg-config \
+            python3 \
+            ragel \
+            wayland-protocols
+
+      - name: Build Ubuntu package
+        run: python3 dev/build_deb.py --output-directory dist
+
+      - name: Validate Ubuntu package
+        run: |
+          packages=(dist/*.deb)
+          if [[ ${#packages[@]} -ne 1 ]]; then
+            echo "expected one Debian package, found ${#packages[@]}" >&2
+            exit 1
+          fi
+          python3 dev/check_deb.py "${packages[0]}"
+          sudo apt-get --simulate install "./${packages[0]}"
+          lintian --fail-on error "${packages[0]}"
+
+      - name: Upload Ubuntu package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ubuntu-deb
+          path: dist/*.deb
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
   build:
     name: Build
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   ubuntu-deb:
     name: Ubuntu package
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 # The release button serializes tag selection, builds the Ubuntu and macOS
 # artifacts in parallel from one commit, then publishes them together.
+# The Homebrew tap picks the release up on its own schedule.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,7 @@
 name: Release
 
-# The release button: publishes the next numeric tag from the current
-# master with a portable darwin-arm64 binary (static utf8proc, no
-# Homebrew dylibs - dev/build_brew_macos.sh guards that) and
-# GitHub-generated notes. The homebrew tap picks the release up on its
-# own schedule.
+# The release button serializes tag selection, builds the Ubuntu and macOS
+# artifacts in parallel from one commit, then publishes them together.
 on:
   workflow_dispatch:
     inputs:
@@ -12,40 +9,200 @@ on:
         description: release tag (empty picks the next number)
         required: false
 
-permissions:
-  attestations: write
-  contents: write
-  id-token: write
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions: {}
 
 jobs:
-  release:
-    runs-on: macos-14
+  prepare:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.source.outputs.sha }}
+      tag: ${{ steps.source.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Install the toolchain
+
+      - name: Resolve release source
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ "$GITHUB_REF" != refs/heads/master ]]; then
+            echo "releases must run from refs/heads/master, not $GITHUB_REF" >&2
+            exit 1
+          fi
+          arguments=()
+          if [[ -n "$REQUESTED_TAG" ]]; then
+            arguments+=("$REQUESTED_TAG")
+          fi
+          tag="$(python3 dev/release.py "${arguments[@]}" --sha "$GITHUB_SHA" --resolve-tag-only)"
+          echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  build-linux:
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - name: Install the Ubuntu toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            binutils \
+            clang \
+            dpkg-dev \
+            file \
+            glslang-tools \
+            libbrotli-dev \
+            libfontconfig-dev \
+            libfreetype-dev \
+            libharfbuzz-dev \
+            librsvg2-bin \
+            libutf8proc-dev \
+            libvulkan-dev \
+            libwayland-dev \
+            libxkbcommon-dev \
+            lintian \
+            pkg-config \
+            python3 \
+            ragel \
+            wayland-protocols
+
+      - name: Build Ubuntu package
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        run: python3 dev/build_deb.py --release-tag "$RELEASE_TAG" --output-directory dist
+
+      - name: Validate Ubuntu package
+        run: |
+          packages=(dist/*.deb)
+          if [[ ${#packages[@]} -ne 1 ]]; then
+            echo "expected one Debian package, found ${#packages[@]}" >&2
+            exit 1
+          fi
+          python3 dev/check_deb.py "${packages[0]}"
+          sudo apt-get --simulate install "./${packages[0]}"
+          lintian --fail-on error "${packages[0]}"
+
+      - name: Upload Ubuntu package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-linux
+          path: dist/*.deb
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+  build-macos:
+    needs: prepare
+    runs-on: macos-14
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Install the macOS toolchain
         run: |
           brew install llvm ragel glslang spirv-cross librsvg
           command -v pkg-config >/dev/null || brew install pkgconf
+
+      - name: Build source and macOS artifacts
+        env:
+          RELEASE_SHA: ${{ needs.prepare.outputs.sha }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          python3 dev/release.py "$RELEASE_TAG" \
+            --sha "$RELEASE_SHA" \
+            --builder brew \
+            --build-only \
+            --artifacts-directory "$RUNNER_TEMP/release-artifacts"
+
+      - name: Upload source and macOS artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-macos
+          path: ${{ runner.temp }}/release-artifacts/*.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+  publish:
+    needs: [prepare, build-linux, build-macos]
+    runs-on: ubuntu-24.04
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: release-*
+          path: ${{ runner.temp }}/release-artifacts
+          merge-multiple: true
+
       - name: Let the release push tags
         run: |
           git config --global user.name "shitty release bot"
           git config --global user.email "noreply@github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         env:
           GH_TOKEN: ${{ github.token }}
+
       - name: Build draft release
-        run: |
-          python3 dev/release.py ${{ inputs.tag }} --sha "$GITHUB_SHA" --builder brew --generate-notes \
-            --artifacts-directory "$RUNNER_TEMP/release-artifacts" --draft \
-            --tag-file "$RUNNER_TEMP/release-tag"
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.prepare.outputs.sha }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          artifacts=("$RUNNER_TEMP/release-artifacts/"*)
+          if [[ ${#artifacts[@]} -ne 3 ]]; then
+            echo "expected three release artifacts, found ${#artifacts[@]}" >&2
+            exit 1
+          fi
+          artifact_arguments=()
+          for artifact_file in "${artifacts[@]}"; do
+            artifact_arguments+=(--artifact "$artifact_file")
+          done
+          python3 dev/release.py "$RELEASE_TAG" \
+            --sha "$RELEASE_SHA" \
+            --generate-notes \
+            --draft \
+            --publish-only \
+            "${artifact_arguments[@]}" \
+            --tag-file "$RUNNER_TEMP/release-tag"
+
       - name: Attest release artifacts
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
-          subject-path: '${{ runner.temp }}/release-artifacts/*.tar.gz'
+          subject-path: '${{ runner.temp }}/release-artifacts/*'
+
       - name: Publish release
         run: gh release edit "$(cat "$RUNNER_TEMP/release-tag")" --draft=false --repo "$GITHUB_REPOSITORY"
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /main_fuzz
 /result
 /result-*
+/dist/
 __pycache__/
 .codegraph/
 /plt_tests

--- a/README.md
+++ b/README.md
@@ -223,7 +223,20 @@ release automatically. The same portable binary (`st-darwin-arm64.tar.gz`,
 nothing dynamically linked outside the system) is attached to every
 [GitHub release](https://github.com/pg83/shitty/releases).
 
-### Linux
+### Ubuntu 24.04 (amd64)
+
+Each GitHub release includes a native package built against Ubuntu 24.04:
+
+```sh
+gh release download --repo pg83/shitty --pattern 'shitty_*_amd64.deb'
+sudo apt install ./shitty_*_amd64.deb
+```
+
+The package installs `st`, the desktop entry, the scalable icon, and the
+project documentation. Its dependencies are derived from the packaged ELF.
+It conflicts with Ubuntu's `stterm` package because both install `/usr/bin/st`.
+
+### Linux from source
 
 The executable is named `st`; the desktop application and icon are named
 `shitty`:

--- a/build.py
+++ b/build.py
@@ -10,7 +10,7 @@ import build
 
 std_build = os.path.join("third_party", "libstd", "build.py")
 plt_build = os.path.join("third_party", "plt", "build.py")
-shitty_version = date.today().strftime("%Y.%m.%d")
+shitty_version = os.environ.get("SHITTY_VERSION", date.today().strftime("%Y.%m.%d"))
 
 build.flags.allow({
     "group": {
@@ -160,8 +160,18 @@ utf8proc = pkg_config("libutf8proc >= 2.9.0")
 threads = dependency(ldflags=["-pthread"])
 
 vulkan = dependency()
+wayland = dependency()
+xkbcommon = dependency()
+realtime = dependency()
+math = dependency()
+cxx_runtime = dependency()
 if linux:
     vulkan = pkg_config("vulkan")
+    wayland = pkg_config("wayland-client >= 1.20")
+    xkbcommon = pkg_config("xkbcommon >= 1.0")
+    realtime = dependency(ldflags=["-lrt"])
+    math = dependency(ldflags=["-lm"])
+    cxx_runtime = dependency(ldflags=["-lstdc++"])
     build.cppflags += ["-DHAVE_VULKAN_WAYLAND=1"]
 
 
@@ -521,15 +531,15 @@ libshitty_test_sources = [
 ]
 libshitty_deps = [
     freetype, fontconfig, harfbuzz, darwin_backend, plt, vulkan, threads, libstd,
-    brotli_common, utf8proc, simdutf,
+    brotli_common, utf8proc, simdutf, wayland, xkbcommon, realtime, math, cxx_runtime,
 ]
 libshitty_test_deps = [
     freetype, fontconfig, harfbuzz, darwin_backend, plt, vulkan, threads, libstd,
-    brotli_common, utf8proc, simdutf,
+    brotli_common, utf8proc, simdutf, wayland, xkbcommon, realtime, math, cxx_runtime,
 ]
 libshitty_fuzz_deps = [
     freetype, fontconfig, harfbuzz, darwin_backend, plt, vulkan, threads, libstd_external_clock,
-    brotli_common, utf8proc, simdutf,
+    brotli_common, utf8proc, simdutf, wayland, xkbcommon, realtime, math, cxx_runtime,
 ]
 
 

--- a/dev/build_deb.py
+++ b/dev/build_deb.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Shitty team
+# MIT licensed
+# See the file LICENSE.MIT for the full license.
+
+import argparse
+import gzip
+import hashlib
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+PACKAGE_NAME = "shitty"
+PACKAGE_ARCHITECTURE = "amd64"
+BUILD_ENVIRONMENT_VARIABLES = (
+    "CFLAGS",
+    "CPPFLAGS",
+    "CXXFLAGS",
+    "LDFLAGS",
+    "LD_LIBRARY_PATH",
+    "LIBRARY_PATH",
+    "CPATH",
+    "C_INCLUDE_PATH",
+    "CPLUS_INCLUDE_PATH",
+    "PKG_CONFIG_PATH",
+    "PKG_CONFIG_LIBDIR",
+)
+
+
+def run(
+    arguments: list[str],
+    *,
+    cwd: Path | None = None,
+    environment: dict[str, str] | None = None,
+    capture: bool = False,
+) -> str:
+    location = f" (in {cwd})" if cwd is not None else ""
+    print(f"+ {shlex.join(arguments)}{location}", file=sys.stderr)
+    result = subprocess.run(
+        arguments,
+        cwd=cwd,
+        env=environment,
+        check=True,
+        stdout=subprocess.PIPE if capture else None,
+        text=True,
+    )
+    return result.stdout.strip() if capture else ""
+
+
+def verify_tools() -> None:
+    tools = (
+        "clang",
+        "clang++",
+        "dpkg",
+        "dpkg-deb",
+        "dpkg-shlibdeps",
+        "git",
+        "glslangValidator",
+        "pkg-config",
+        "ragel",
+        "rsvg-convert",
+        "strip",
+        "wayland-scanner",
+    )
+    for tool in tools:
+        if not shutil.which(tool):
+            raise RuntimeError(f"required tool is not available: {tool}")
+
+
+def git_value(project_root: Path, format_string: str) -> str:
+    return run(
+        ["git", "show", "-s", f"--format={format_string}", "HEAD"],
+        cwd=project_root,
+        capture=True,
+    )
+
+
+def verify_source_tree(project_root: Path) -> None:
+    status = run(
+        ["git", "status", "--porcelain", "--untracked-files=normal"],
+        cwd=project_root,
+        capture=True,
+    )
+    if status:
+        raise RuntimeError("refusing to package a dirty source tree")
+
+
+def source_version(timestamp: int) -> str:
+    return datetime.fromtimestamp(timestamp, UTC).strftime("%Y.%m.%d")
+
+
+def package_version(project_root: Path, timestamp: int, release_tag: str | None) -> str:
+    if release_tag is not None:
+        if (
+            not release_tag.isascii()
+            or not release_tag.isdecimal()
+            or release_tag.startswith("0")
+        ):
+            raise RuntimeError(
+                "release tag must be a positive decimal integer without leading zeroes"
+            )
+        version = release_tag
+    else:
+        revision = git_value(project_root, "%h")
+        date = datetime.fromtimestamp(timestamp, UTC).strftime("%Y%m%d")
+        version = f"0~git{date}.{revision}"
+    run(["dpkg", "--validate-version", version])
+    return version
+
+
+def clean_build_environment(
+    timestamp: int,
+    sha: str | None = None,
+) -> dict[str, str]:
+    environment = os.environ.copy()
+    for variable in BUILD_ENVIRONMENT_VARIABLES:
+        environment.pop(variable, None)
+    build_id = "sha1" if sha is None else f"0x{sha}"
+    environment.update(
+        {
+            "CC": "clang",
+            "CXX": "clang++",
+            "LDFLAGS": f"-Wl,--as-needed,--build-id={build_id}",
+            "SHITTY_VERSION": source_version(timestamp),
+            "SOURCE_DATE_EPOCH": str(timestamp),
+        }
+    )
+    environment["CPPFLAGS"] = shlex.join(
+        [
+            "-ffile-prefix-map=$(S)=/usr/src/shitty",
+            "-ffile-prefix-map=$(B)=/usr/src/shitty/.build",
+        ]
+    )
+    return environment
+
+
+def derive_dependencies(binary: Path, environment: dict[str, str]) -> str:
+    with tempfile.TemporaryDirectory(prefix="shitty-shlibdeps-") as temporary_name:
+        temporary = Path(temporary_name)
+        debian = temporary / "debian"
+        debian.mkdir()
+        (debian / "control").write_text(
+            f"Source: {PACKAGE_NAME}\n"
+            "Section: x11\n"
+            "Priority: optional\n"
+            "Maintainer: Shitty team <noreply@github.com>\n"
+            "\n"
+            f"Package: {PACKAGE_NAME}\n"
+            f"Architecture: {PACKAGE_ARCHITECTURE}\n"
+            "Description: dependency scan\n"
+        )
+        installed_binary = debian / PACKAGE_NAME / "usr/bin/st"
+        installed_binary.parent.mkdir(parents=True)
+        shutil.copyfile(binary, installed_binary)
+        output = run(
+            ["dpkg-shlibdeps", "-O", f"-e{installed_binary.relative_to(temporary)}"],
+            cwd=temporary,
+            environment=environment,
+            capture=True,
+        )
+    prefix = "shlibs:Depends="
+    lines = [
+        line.removeprefix(prefix)
+        for line in output.splitlines()
+        if line.startswith(prefix)
+    ]
+    if len(lines) != 1 or not lines[0]:
+        raise RuntimeError(f"dpkg-shlibdeps returned unexpected output: {output!r}")
+    return lines[0]
+
+
+def copy_payload(project_root: Path, package_root: Path, binary: Path) -> None:
+    files = {
+        binary: package_root / "usr/bin/st",
+        project_root / "shitty.desktop": package_root
+        / "usr/share/applications/shitty.desktop",
+        project_root / "shitty.svg": package_root
+        / "usr/share/icons/hicolor/scalable/apps/shitty.svg",
+        project_root / "README.md": package_root / "usr/share/doc/shitty/README.md",
+        project_root / "LICENSE": package_root / "usr/share/doc/shitty/LICENSING",
+        project_root / "LICENSE.MIT": package_root / "usr/share/doc/shitty/LICENSE.MIT",
+        project_root / "fonts/OFL.txt": package_root
+        / "usr/share/doc/shitty/LICENSE.OFL",
+        project_root / "fonts/LICENSE.NotoColorEmoji": package_root
+        / "usr/share/doc/shitty/LICENSE.NotoColorEmoji",
+    }
+    for source, destination in files.items():
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+        destination.chmod(
+            0o755 if destination == package_root / "usr/bin/st" else 0o644
+        )
+
+
+def write_copyright(package_root: Path) -> None:
+    contents = """Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Shitty
+Source: https://github.com/pg83/shitty
+
+Files: *
+Copyright: 2020 Tom Szilagyi
+           2026 Shitty team
+License: GPL-3+
+ The imported baseline remains licensed under the GNU General Public License,
+ version 3 or any later version. Shitty contributions are also available under
+ the MIT license; see /usr/share/doc/shitty/LICENSING and LICENSE.MIT.
+ .
+ On Debian systems, the complete text of the GNU General Public License,
+ version 3, is available in /usr/share/common-licenses/GPL-3.
+
+Files: fonts/JetBrainsMonoNerdFont-Regular.ttf
+Copyright: 2020 The JetBrains Mono Project Authors
+           Nerd Fonts project contributors
+License: OFL-1.1
+ See /usr/share/doc/shitty/LICENSE.OFL.
+
+Files: fonts/NotoColorEmoji.ttf fonts/NotoEmoji-Regular.ttf
+Copyright: 2013 Google LLC
+License: OFL-1.1
+ See /usr/share/doc/shitty/LICENSE.NotoColorEmoji.
+"""
+    output = package_root / "usr/share/doc/shitty/copyright"
+    output.write_text(contents)
+    output.chmod(0o644)
+
+
+def write_source(package_root: Path, sha: str, binary_version: str) -> None:
+    output = package_root / "usr/share/doc/shitty/SOURCE"
+    output.write_text(f"commit {sha}\nbinary-version {binary_version}\n")
+    output.chmod(0o644)
+
+
+def write_changelog(package_root: Path, version: str, timestamp: int) -> None:
+    date = datetime.fromtimestamp(timestamp, UTC).strftime(
+        "%a, %d %b %Y %H:%M:%S +0000"
+    )
+    contents = (
+        f"shitty ({version}) unstable; urgency=medium\n\n"
+        "  * Build the upstream Shitty release.\n\n"
+        f" -- Shitty team <noreply@github.com>  {date}\n"
+    ).encode()
+    output = package_root / "usr/share/doc/shitty/changelog.gz"
+    with (
+        output.open("wb") as output_file,
+        gzip.GzipFile(
+            filename="",
+            mode="wb",
+            fileobj=output_file,
+            compresslevel=9,
+            mtime=timestamp,
+        ) as archive,
+    ):
+        archive.write(contents)
+    output.chmod(0o644)
+
+
+def installed_size(package_root: Path) -> int:
+    size = sum(
+        item.stat().st_size for item in package_root.rglob("*") if item.is_file()
+    )
+    return max(1, (size + 1023) // 1024)
+
+
+def write_control(package_root: Path, version: str, dependencies: str) -> None:
+    control_directory = package_root / "DEBIAN"
+    control_directory.mkdir(mode=0o755)
+    control = (
+        f"Package: {PACKAGE_NAME}\n"
+        f"Version: {version}\n"
+        f"Architecture: {PACKAGE_ARCHITECTURE}\n"
+        "Maintainer: Shitty team <noreply@github.com>\n"
+        "Section: x11\n"
+        "Priority: optional\n"
+        f"Installed-Size: {installed_size(package_root)}\n"
+        f"Depends: {dependencies}\n"
+        "Conflicts: stterm\n"
+        "Replaces: stterm\n"
+        "Homepage: https://github.com/pg83/shitty\n"
+        "Description: fast Wayland and Vulkan terminal emulator\n"
+        " Shitty is a low-latency terminal emulator with a native Wayland\n"
+        " frontend, Vulkan rendering, Unicode grapheme support, and embedded\n"
+        " fallback fonts. This package targets Ubuntu 24.04 amd64.\n"
+    )
+    (control_directory / "control").write_text(control)
+
+
+def write_md5sums(package_root: Path) -> None:
+    entries = []
+    for item in sorted(package_root.rglob("*")):
+        if item.is_file() and "DEBIAN" not in item.relative_to(package_root).parts:
+            digest = hashlib.md5(item.read_bytes()).hexdigest()
+            entries.append(f"{digest}  {item.relative_to(package_root).as_posix()}")
+    output = package_root / "DEBIAN/md5sums"
+    output.write_text("\n".join(entries) + "\n")
+    output.chmod(0o644)
+
+
+def normalize_timestamps(package_root: Path, timestamp: int) -> None:
+    items = [package_root, *sorted(package_root.rglob("*"))]
+    for item in items:
+        if item.is_dir():
+            item.chmod(0o755)
+        os.utime(item, (timestamp, timestamp), follow_symlinks=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build an Ubuntu 24.04 amd64 Shitty package."
+    )
+    parser.add_argument(
+        "--release-tag", help="numeric GitHub release tag used as the Debian revision"
+    )
+    parser.add_argument("--build-directory", type=Path, default=Path(".build-deb"))
+    parser.add_argument("--output-directory", type=Path, default=Path("dist"))
+    parser.add_argument("--jobs", type=int, default=os.cpu_count() or 1)
+    arguments = parser.parse_args()
+    if arguments.jobs < 1:
+        parser.error("--jobs must be positive")
+
+    verify_tools()
+    project_root = Path(__file__).resolve().parent.parent
+    verify_source_tree(project_root)
+    architecture = run(["dpkg", "--print-architecture"], capture=True)
+    if architecture != PACKAGE_ARCHITECTURE:
+        raise RuntimeError(
+            f"package builder requires {PACKAGE_ARCHITECTURE}, got {architecture}"
+        )
+    timestamp = int(git_value(project_root, "%ct"))
+    sha = git_value(project_root, "%H")
+    version = package_version(project_root, timestamp, arguments.release_tag)
+    build_directory = arguments.build_directory
+    if not build_directory.is_absolute():
+        build_directory = project_root / build_directory
+    output_directory = arguments.output_directory
+    if not output_directory.is_absolute():
+        output_directory = project_root / output_directory
+    output_directory.mkdir(parents=True, exist_ok=True)
+    environment = clean_build_environment(timestamp, sha)
+
+    run(
+        [
+            os.fspath(project_root / "build"),
+            "-B",
+            os.fspath(build_directory),
+            "-j",
+            str(arguments.jobs),
+            "st",
+        ],
+        cwd=project_root,
+        environment=environment,
+    )
+    binary = build_directory / "st"
+    if not binary.is_file():
+        raise RuntimeError(f"build did not produce {binary}")
+
+    with tempfile.TemporaryDirectory(prefix="shitty-deb-root-") as temporary_name:
+        package_root = Path(temporary_name)
+        copy_payload(project_root, package_root, binary)
+        packaged_binary = package_root / "usr/bin/st"
+        run(
+            ["strip", "--strip-unneeded", os.fspath(packaged_binary)],
+            environment=environment,
+        )
+        dependencies = derive_dependencies(packaged_binary, environment)
+        write_copyright(package_root)
+        write_source(package_root, sha, source_version(timestamp))
+        write_changelog(package_root, version, timestamp)
+        write_control(package_root, version, dependencies)
+        write_md5sums(package_root)
+        normalize_timestamps(package_root, timestamp)
+        filename_version = version.replace(":", "%3a")
+        output = (
+            output_directory
+            / f"{PACKAGE_NAME}_{filename_version}_{PACKAGE_ARCHITECTURE}.deb"
+        )
+        if output.exists():
+            raise RuntimeError(f"refusing to overwrite existing package: {output}")
+        run(
+            [
+                "dpkg-deb",
+                "--root-owner-group",
+                "--build",
+                "--uniform-compression",
+                "--threads-max=1",
+                "-Zxz",
+                "-z9",
+                os.fspath(package_root),
+                os.fspath(output),
+            ],
+            environment=environment,
+        )
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/check_deb.py
+++ b/dev/check_deb.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Shitty team
+# MIT licensed
+# See the file LICENSE.MIT for the full license.
+
+import argparse
+import hashlib
+import io
+import os
+import re
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+from build_deb import (
+    PACKAGE_ARCHITECTURE,
+    PACKAGE_NAME,
+    clean_build_environment,
+    derive_dependencies,
+    run,
+)
+
+PAYLOAD_MODES = {
+    "usr/bin/st": 0o755,
+    "usr/share/applications/shitty.desktop": 0o644,
+    "usr/share/icons/hicolor/scalable/apps/shitty.svg": 0o644,
+    "usr/share/doc/shitty/README.md": 0o644,
+    "usr/share/doc/shitty/LICENSING": 0o644,
+    "usr/share/doc/shitty/SOURCE": 0o644,
+    "usr/share/doc/shitty/copyright": 0o644,
+    "usr/share/doc/shitty/LICENSE.MIT": 0o644,
+    "usr/share/doc/shitty/LICENSE.OFL": 0o644,
+    "usr/share/doc/shitty/LICENSE.NotoColorEmoji": 0o644,
+    "usr/share/doc/shitty/changelog.gz": 0o644,
+}
+
+
+def field(package: Path, name: str) -> str:
+    return run(["dpkg-deb", "--field", os.fspath(package), name], capture=True)
+
+
+def check_payload(package: Path) -> None:
+    archive_data = subprocess.check_output(["dpkg-deb", "--fsys-tarfile", package])
+    with tarfile.open(fileobj=io.BytesIO(archive_data), mode="r:") as archive:
+        regular = {}
+        for member in archive.getmembers():
+            normalized = member.name.removeprefix("./")
+            if member.uid != 0 or member.gid != 0:
+                raise RuntimeError(f"payload member is not root-owned: {member.name}")
+            if member.isdir() and member.mode & 0o7777 != 0o755:
+                raise RuntimeError(
+                    f"payload directory has unexpected mode: {member.name}"
+                )
+            if member.isfile():
+                regular[normalized] = member.mode & 0o7777
+        if regular != PAYLOAD_MODES:
+            raise RuntimeError(f"unexpected payload files or modes: {regular!r}")
+
+
+def check_md5sums(package: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="shitty-deb-control-") as control_name:
+        control = Path(control_name)
+        run(["dpkg-deb", "--control", os.fspath(package), os.fspath(control)])
+        expected = {}
+        for line in (control / "md5sums").read_text().splitlines():
+            digest, relative = line.split(maxsplit=1)
+            expected[relative] = digest
+    with tempfile.TemporaryDirectory(prefix="shitty-deb-md5-") as payload_name:
+        payload = Path(payload_name)
+        run(["dpkg-deb", "--extract", os.fspath(package), os.fspath(payload)])
+        actual = {
+            relative: hashlib.md5((payload / relative).read_bytes()).hexdigest()
+            for relative in expected
+        }
+    if actual != expected:
+        raise RuntimeError("payload does not match DEBIAN/md5sums")
+
+
+def check_extracted_binary(package: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="shitty-deb-check-") as temporary_name:
+        root = Path(temporary_name)
+        run(["dpkg-deb", "--extract", os.fspath(package), os.fspath(root)])
+        binary = root / "usr/bin/st"
+        environment = clean_build_environment(0)
+        description = run(
+            ["file", os.fspath(binary)], environment=environment, capture=True
+        )
+        if not all(
+            marker in description for marker in ("ELF 64-bit", "x86-64", "executable")
+        ):
+            raise RuntimeError(f"unexpected packaged binary: {description}")
+        source = (root / "usr/share/doc/shitty/SOURCE").read_text()
+        match = re.fullmatch(
+            r"commit ([0-9a-f]{40})\nbinary-version ([0-9]{4}\.[0-9]{2}\.[0-9]{2})\n",
+            source,
+        )
+        if match is None:
+            raise RuntimeError(f"unexpected SOURCE metadata: {source!r}")
+        sha, binary_version = match.groups()
+        notes = run(
+            ["readelf", "-n", os.fspath(binary)], environment=environment, capture=True
+        )
+        if not re.search(rf"^\s*Build ID: {sha}$", notes, re.MULTILINE):
+            raise RuntimeError(
+                f"packaged binary build ID does not match source commit {sha}"
+            )
+        dynamic = run(
+            ["readelf", "-d", os.fspath(binary)], environment=environment, capture=True
+        )
+        if "RPATH" in dynamic or "RUNPATH" in dynamic:
+            raise RuntimeError("packaged binary contains an RPATH or RUNPATH")
+        dependencies = derive_dependencies(binary, environment)
+        if field(package, "Depends") != dependencies:
+            raise RuntimeError("declared Depends do not match dpkg-shlibdeps")
+        linked = run(["ldd", os.fspath(binary)], environment=environment, capture=True)
+        if "not found" in linked:
+            raise RuntimeError(f"unresolved runtime library:\n{linked}")
+        reported_version = run(
+            [os.fspath(binary), "-v"], environment=environment, capture=True
+        )
+        if not reported_version.startswith(f"Shitty {binary_version}\n"):
+            raise RuntimeError(f"unexpected version output: {reported_version!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a Shitty Ubuntu package without installing it."
+    )
+    parser.add_argument("package", type=Path)
+    arguments = parser.parse_args()
+    package = arguments.package.resolve(strict=True)
+
+    run(["dpkg-deb", "--info", os.fspath(package)])
+    run(["dpkg-deb", "--contents", os.fspath(package)])
+    if field(package, "Package") != PACKAGE_NAME:
+        raise RuntimeError("unexpected package name")
+    if field(package, "Architecture") != PACKAGE_ARCHITECTURE:
+        raise RuntimeError("unexpected package architecture")
+    version = field(package, "Version")
+    run(["dpkg", "--validate-version", version])
+    check_payload(package)
+    check_md5sums(package)
+    check_extracted_binary(package)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/release.py
+++ b/dev/release.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -35,27 +36,34 @@ def run(
     return result.stdout.strip() if capture else ""
 
 
-def verify_tools() -> None:
-    for tool in ("git", "gh", "file"):
+def verify_tools(*, github: bool = False, debian: bool = False) -> None:
+    tools = ["git", "file"]
+    if github:
+        tools.append("gh")
+    if debian:
+        tools.append("dpkg-deb")
+    for tool in tools:
         if not shutil.which(tool):
             raise RuntimeError(f"required tool is not available: {tool}")
 
 
 def release_tags(repository: str) -> list[int]:
-    releases = json.loads(run(
-        [
-            "gh",
-            "release",
-            "list",
-            "--repo",
-            repository,
-            "--limit",
-            "1000",
-            "--json",
-            "tagName",
-        ],
-        capture=True,
-    ))
+    releases = json.loads(
+        run(
+            [
+                "gh",
+                "release",
+                "list",
+                "--repo",
+                repository,
+                "--limit",
+                "1000",
+                "--json",
+                "tagName",
+            ],
+            capture=True,
+        )
+    )
     return [
         int(release["tagName"])
         for release in releases
@@ -64,11 +72,15 @@ def release_tags(repository: str) -> list[int]:
 
 
 def release_exists(repository: str, tag: str) -> bool:
-    return subprocess.run(
-        ["gh", "release", "view", tag, "--repo", repository],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    ).returncode == 0
+    return (
+        subprocess.run(
+            ["gh", "release", "view", tag, "--repo", repository],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
 
 
 def remote_refs(remote: str, tag: str) -> dict[str, str]:
@@ -97,7 +109,9 @@ def verify_remote_refs(refs: dict[str, str], tag: str, sha: str) -> tuple[bool, 
     branch_exists = branch_name in refs
     tag_exists = tag_name in refs
     if branch_exists and refs[branch_name] != sha:
-        raise RuntimeError(f"remote branch {tag} points to {refs[branch_name]}, not {sha}")
+        raise RuntimeError(
+            f"remote branch {tag} points to {refs[branch_name]}, not {sha}"
+        )
     tag_commit = refs.get(peeled_tag_name, refs.get(tag_name))
     if tag_commit is not None and tag_commit != sha:
         raise RuntimeError(f"remote tag {tag} points to {tag_commit}, not {sha}")
@@ -124,20 +138,22 @@ def write_tar(
     timestamp: int,
     write_contents,
 ) -> None:
-    with output.open("wb") as compressed_file:
-        with gzip.GzipFile(
+    with (
+        output.open("wb") as compressed_file,
+        gzip.GzipFile(
             filename="",
             mode="wb",
             fileobj=compressed_file,
             compresslevel=9,
             mtime=timestamp,
-        ) as gzip_file:
-            with tarfile.open(
-                fileobj=gzip_file,
-                mode="w",
-                format=tarfile.GNU_FORMAT,
-            ) as archive:
-                write_contents(archive)
+        ) as gzip_file,
+        tarfile.open(
+            fileobj=gzip_file,
+            mode="w",
+            format=tarfile.GNU_FORMAT,
+        ) as archive,
+    ):
+        write_contents(archive)
 
 
 def create_source_archive(
@@ -150,11 +166,7 @@ def create_source_archive(
         ["git", "ls-files", "-z"],
         cwd=checkout,
     ).split(b"\0")
-    paths = sorted(
-        Path(os.fsdecode(name))
-        for name in tracked
-        if name
-    )
+    paths = sorted(Path(os.fsdecode(name)) for name in tracked if name)
 
     def write_contents(archive: tarfile.TarFile) -> None:
         root = tarfile.TarInfo(f"{prefix}/")
@@ -197,11 +209,213 @@ def create_binary_archive(
     write_tar(output, timestamp, write_contents)
 
 
+def resolve_release_tag(repository: str, requested_tag: str | None) -> str:
+    numeric_tags = release_tags(repository)
+    expected_tag = max(numeric_tags, default=0) + 1
+    tag = requested_tag or str(expected_tag)
+    if release_exists(repository, tag):
+        raise RuntimeError(f"release {tag} already exists")
+    if int(tag) != expected_tag:
+        raise RuntimeError(f"next release tag is {expected_tag}, not {tag}")
+    return tag
+
+
+def checkout_commit(remote: str, sha: str, destination: Path) -> str:
+    run(["git", "clone", "--no-checkout", remote, os.fspath(destination)])
+    resolved_sha = run(
+        ["git", "rev-parse", "--verify", f"{sha}^{{commit}}"],
+        cwd=destination,
+        capture=True,
+    )
+    run(["git", "checkout", "--detach", resolved_sha], cwd=destination)
+    return resolved_sha
+
+
+def build_release_artifacts(
+    remote: str,
+    sha: str,
+    tag: str,
+    builder: str,
+    artifacts: Path,
+) -> list[Path]:
+    artifacts.mkdir(parents=True, exist_ok=True)
+    source_archive = artifacts / f"shitty-{tag}.tar.gz"
+    binary_archive = artifacts / "st-darwin-arm64.tar.gz"
+    for output in (source_archive, binary_archive):
+        if output.exists():
+            raise RuntimeError(f"refusing to overwrite existing artifact: {output}")
+    with tempfile.TemporaryDirectory(
+        prefix=f"shitty-release-build-{tag}-"
+    ) as temporary_name:
+        checkout = Path(temporary_name) / "checkout"
+        resolved_sha = checkout_commit(remote, sha, checkout)
+        timestamp = int(
+            run(
+                ["git", "show", "-s", "--format=%ct", resolved_sha],
+                cwd=checkout,
+                capture=True,
+            )
+        )
+        create_source_archive(checkout, source_archive, f"shitty-{tag}", timestamp)
+        builder_script = (
+            "build_ix_macos.sh" if builder == "ix" else "build_brew_macos.sh"
+        )
+        run([os.fspath(checkout / "dev" / builder_script)], cwd=checkout)
+        binary = checkout / ".build-darwin" / "st"
+        if not binary.is_file():
+            raise RuntimeError(f"Darwin build did not produce {binary}")
+        binary = binary.resolve(strict=True)
+        file_description = run(["file", os.fspath(binary)], capture=True)
+        if not all(
+            marker in file_description
+            for marker in ("Mach-O 64-bit", "arm64", "executable")
+        ):
+            raise RuntimeError(f"unexpected Darwin artifact: {file_description}")
+        create_binary_archive(binary, binary_archive, timestamp)
+    return [source_archive, binary_archive]
+
+
+def verify_release_artifacts(
+    artifacts: list[Path],
+    tag: str,
+    sha: str,
+    timestamp: int,
+) -> list[Path]:
+    resolved = [artifact.resolve(strict=True) for artifact in artifacts]
+    by_name = {artifact.name: artifact for artifact in resolved}
+    if len(by_name) != len(resolved):
+        raise RuntimeError("release artifacts must have unique filenames")
+    debs = [
+        artifact
+        for artifact in resolved
+        if artifact.name.startswith("shitty_") and artifact.name.endswith("_amd64.deb")
+    ]
+    if len(debs) != 1:
+        raise RuntimeError("release requires exactly one shitty_*_amd64.deb artifact")
+    actual_version = run(
+        ["dpkg-deb", "--field", os.fspath(debs[0]), "Version"],
+        capture=True,
+    )
+    if actual_version != tag:
+        raise RuntimeError(
+            f"Debian artifact version is {actual_version}, expected {tag}"
+        )
+    expected_binary_version = datetime.fromtimestamp(timestamp, UTC).strftime(
+        "%Y.%m.%d"
+    )
+    with tempfile.TemporaryDirectory(prefix="shitty-release-deb-") as temporary_name:
+        root = Path(temporary_name)
+        run(["dpkg-deb", "--extract", os.fspath(debs[0]), os.fspath(root)])
+        source = (root / "usr/share/doc/shitty/SOURCE").read_text()
+    expected_source = f"commit {sha}\nbinary-version {expected_binary_version}\n"
+    if source != expected_source:
+        raise RuntimeError(
+            f"Debian artifact SOURCE metadata is {source!r}, expected {expected_source!r}"
+        )
+    expected_names = {
+        f"shitty-{tag}.tar.gz",
+        "st-darwin-arm64.tar.gz",
+        debs[0].name,
+    }
+    if set(by_name) != expected_names:
+        raise RuntimeError(f"unexpected release artifact set: {sorted(by_name)}")
+    return [by_name[name] for name in sorted(expected_names)]
+
+
+def publish_release(
+    remote: str,
+    repository: str,
+    sha: str,
+    tag: str,
+    artifacts: list[Path],
+    notes: str,
+    *,
+    generate_notes: bool,
+    draft: bool,
+) -> str:
+    with tempfile.TemporaryDirectory(
+        prefix=f"shitty-release-publish-{tag}-"
+    ) as temporary_name:
+        temporary = Path(temporary_name)
+        checkout = temporary / "checkout"
+        resolved_sha = checkout_commit(remote, sha, checkout)
+        timestamp = int(
+            run(
+                ["git", "show", "-s", "--format=%ct", resolved_sha],
+                cwd=checkout,
+                capture=True,
+            )
+        )
+        verified_artifacts = verify_release_artifacts(
+            artifacts,
+            tag,
+            resolved_sha,
+            timestamp,
+        )
+        notes_file = temporary / "release-notes.md"
+        if not generate_notes:
+            notes_file.write_text(f"{notes}\n")
+
+        refs = remote_refs(remote, tag)
+        branch_exists, tag_exists = verify_remote_refs(refs, tag, resolved_sha)
+        if not tag_exists:
+            run(
+                ["git", "tag", "-a", tag, resolved_sha, "-m", f"Release {tag}"],
+                cwd=checkout,
+            )
+        refspecs = []
+        if not branch_exists:
+            refspecs.append(f"{resolved_sha}:refs/heads/{tag}")
+        if not tag_exists:
+            refspecs.append(f"refs/tags/{tag}:refs/tags/{tag}")
+        if refspecs:
+            run(["git", "push", "--atomic", "origin", *refspecs], cwd=checkout)
+
+        run(
+            [
+                "gh",
+                "release",
+                "create",
+                tag,
+                *[os.fspath(artifact) for artifact in verified_artifacts],
+                "--repo",
+                repository,
+                "--verify-tag",
+                "--title",
+                tag,
+                *(
+                    ["--generate-notes"]
+                    if generate_notes
+                    else ["--notes-file", os.fspath(notes_file)]
+                ),
+                *(["--draft"] if draft else []),
+            ],
+            cwd=checkout,
+        )
+        return run(
+            [
+                "gh",
+                "release",
+                "view",
+                tag,
+                "--repo",
+                repository,
+                "--json",
+                "url",
+                "--jq",
+                ".url",
+            ],
+            capture=True,
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Build and publish a Shitty GitHub release.",
     )
-    parser.add_argument("tag", nargs="?", help="numeric release tag; omitted picks the next")
+    parser.add_argument(
+        "tag", nargs="?", help="numeric release tag; omitted picks the next"
+    )
     parser.add_argument("--sha", default="HEAD", help="git commit to release")
     parser.add_argument(
         "--builder",
@@ -229,24 +443,51 @@ def main() -> int:
         type=Path,
         help="write the resolved tag to this file after creating the release",
     )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--resolve-tag-only",
+        action="store_true",
+        help="print the next validated release tag without building or publishing",
+    )
+    mode.add_argument(
+        "--build-only",
+        action="store_true",
+        help="build source and Darwin artifacts without creating refs or a release",
+    )
+    mode.add_argument(
+        "--publish-only",
+        action="store_true",
+        help="publish prebuilt artifacts without rebuilding them",
+    )
+    parser.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        type=Path,
+        help="prebuilt artifact to attach in --publish-only mode; repeat for each file",
+    )
     arguments = parser.parse_args()
 
     if arguments.tag is not None and not re.fullmatch(r"[1-9][0-9]*", arguments.tag):
         parser.error("tag must be a positive decimal integer without leading zeroes")
 
-    verify_tools()
-    notes = "" if arguments.generate_notes else sys.stdin.read().strip()
-    if not notes and not arguments.generate_notes:
-        parser.error("release notes must be provided on stdin")
+    if arguments.build_only and (
+        arguments.tag is None or arguments.artifacts_directory is None
+    ):
+        parser.error("--build-only requires an explicit tag and --artifacts-directory")
+    if arguments.publish_only and not arguments.artifact:
+        parser.error("--publish-only requires --artifact")
+    if arguments.artifact and not arguments.publish_only:
+        parser.error("--artifact is only valid with --publish-only")
+
+    verify_tools(
+        github=not arguments.build_only,
+        debian=arguments.publish_only,
+    )
 
     project_root = Path(__file__).resolve().parent.parent
     remote = run(
         ["git", "remote", "get-url", "origin"],
-        cwd=project_root,
-        capture=True,
-    )
-    repository = run(
-        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
         cwd=project_root,
         capture=True,
     )
@@ -255,126 +496,43 @@ def main() -> int:
         cwd=project_root,
         capture=True,
     )
-
-    numeric_tags = release_tags(repository)
-    expected_tag = max(numeric_tags, default=0) + 1
-    if arguments.tag is None:
-        arguments.tag = str(expected_tag)
-    if release_exists(repository, arguments.tag):
-        raise RuntimeError(f"release {arguments.tag} already exists")
-    if int(arguments.tag) != expected_tag:
-        raise RuntimeError(f"next release tag is {expected_tag}, not {arguments.tag}")
-
-    with tempfile.TemporaryDirectory(prefix=f"shitty-release-{arguments.tag}-") as temporary_name:
-        temporary = Path(temporary_name)
-        checkout = temporary / "checkout"
-        if arguments.artifacts_directory is None:
-            artifacts = temporary / "artifacts"
-        else:
-            artifacts = arguments.artifacts_directory.resolve()
-        artifacts.mkdir(parents=True)
-
-        run(["git", "clone", "--no-checkout", remote, os.fspath(checkout)])
-        resolved_sha = run(
-            ["git", "rev-parse", "--verify", f"{local_sha}^{{commit}}"],
-            cwd=checkout,
-            capture=True,
-        )
-        run(["git", "checkout", "--detach", resolved_sha], cwd=checkout)
-        timestamp = int(run(
-            ["git", "show", "-s", "--format=%ct", resolved_sha],
-            cwd=checkout,
-            capture=True,
-        ))
-        source_archive = artifacts / f"shitty-{arguments.tag}.tar.gz"
-        binary_archive = artifacts / "st-darwin-arm64.tar.gz"
-        notes_file = artifacts / "release-notes.md"
-        if not arguments.generate_notes:
-            notes_file.write_text(f"{notes}\n")
-
-        create_source_archive(
-            checkout,
-            source_archive,
-            f"shitty-{arguments.tag}",
-            timestamp,
-        )
-        builder = "build_ix_macos.sh" if arguments.builder == "ix" else "build_brew_macos.sh"
-        run([os.fspath(checkout / "dev" / builder)], cwd=checkout)
-        binary = checkout / ".build-darwin" / "st"
-        if not binary.is_file():
-            raise RuntimeError(f"Darwin build did not produce {binary}")
-        binary = binary.resolve(strict=True)
-        file_description = run(["file", os.fspath(binary)], capture=True)
-        if not all(marker in file_description for marker in ("Mach-O 64-bit", "arm64", "executable")):
-            raise RuntimeError(f"unexpected Darwin artifact: {file_description}")
-        create_binary_archive(binary, binary_archive, timestamp)
-
-        refs = remote_refs(remote, arguments.tag)
-        branch_exists, tag_exists = verify_remote_refs(
-            refs,
+    if arguments.build_only:
+        build_release_artifacts(
+            remote,
+            local_sha,
             arguments.tag,
-            resolved_sha,
+            arguments.builder,
+            arguments.artifacts_directory.resolve(),
         )
-        if not tag_exists:
-            run(
-                [
-                    "git",
-                    "tag",
-                    "-a",
-                    arguments.tag,
-                    resolved_sha,
-                    "-m",
-                    f"Release {arguments.tag}",
-                ],
-                cwd=checkout,
-            )
-        refspecs = []
-        if not branch_exists:
-            refspecs.append(f"{resolved_sha}:refs/heads/{arguments.tag}")
-        if not tag_exists:
-            refspecs.append(f"refs/tags/{arguments.tag}:refs/tags/{arguments.tag}")
-        if refspecs:
-            run(["git", "push", "--atomic", "origin", *refspecs], cwd=checkout)
+        return 0
 
-        run(
-            [
-                "gh",
-                "release",
-                "create",
-                arguments.tag,
-                os.fspath(source_archive),
-                os.fspath(binary_archive),
-                "--repo",
-                repository,
-                "--verify-tag",
-                "--title",
-                arguments.tag,
-                *(
-                    ["--generate-notes"]
-                    if arguments.generate_notes
-                    else ["--notes-file", os.fspath(notes_file)]
-                ),
-                *(["--draft"] if arguments.draft else []),
-            ],
-            cwd=checkout,
-        )
-        if arguments.tag_file is not None:
-            arguments.tag_file.write_text(f"{arguments.tag}\n")
-        print(run(
-            [
-                "gh",
-                "release",
-                "view",
-                arguments.tag,
-                "--repo",
-                repository,
-                "--json",
-                "url",
-                "--jq",
-                ".url",
-            ],
-            capture=True,
-        ))
+    repository = run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        cwd=project_root,
+        capture=True,
+    )
+    tag = resolve_release_tag(repository, arguments.tag)
+    if arguments.resolve_tag_only:
+        print(tag)
+        return 0
+
+    notes = "" if arguments.generate_notes else sys.stdin.read().strip()
+    if not notes and not arguments.generate_notes:
+        parser.error("release notes must be provided on stdin")
+
+    url = publish_release(
+        remote,
+        repository,
+        local_sha,
+        tag,
+        arguments.artifact,
+        notes,
+        generate_notes=arguments.generate_notes,
+        draft=arguments.draft,
+    )
+    if arguments.tag_file is not None:
+        arguments.tag_file.write_text(f"{tag}\n")
+    print(url)
     return 0
 
 

--- a/render_vk.cpp
+++ b/render_vk.cpp
@@ -58,6 +58,18 @@
 using namespace stl;
 
 namespace {
+    #if defined(VK_KHR_swapchain_maintenance1)
+        using SwapchainMaintenanceFeatures = VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR;
+        using SwapchainPresentFenceInfo = VkSwapchainPresentFenceInfoKHR;
+        constexpr VkStructureType swapchainMaintenanceFeaturesType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_KHR;
+        constexpr VkStructureType swapchainPresentFenceInfoType = VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_KHR;
+    #else
+        using SwapchainMaintenanceFeatures = VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT;
+        using SwapchainPresentFenceInfo = VkSwapchainPresentFenceInfoEXT;
+        constexpr VkStructureType swapchainMaintenanceFeaturesType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT;
+        constexpr VkStructureType swapchainPresentFenceInfoType = VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_EXT;
+    #endif
+
     struct RendererImpl;
 
     struct CallRendererFontChanged final: public Listener {
@@ -541,11 +553,15 @@ void RendererImpl::createInstance() {
     const char* extensions[5] = {VK_KHR_SURFACE_EXTENSION_NAME};
     u32 extensionCount = 1;
     extensions[extensionCount++] = VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;
-    khrSurfaceMaintenance = instanceHasExtension(VK_KHR_SURFACE_MAINTENANCE_1_EXTENSION_NAME);
+    #if defined(VK_KHR_surface_maintenance1)
+        khrSurfaceMaintenance = instanceHasExtension(VK_KHR_SURFACE_MAINTENANCE_1_EXTENSION_NAME);
+    #endif
     extSurfaceMaintenance = instanceHasExtension(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME);
-    if (khrSurfaceMaintenance) {
-        extensions[extensionCount++] = VK_KHR_SURFACE_MAINTENANCE_1_EXTENSION_NAME;
-    }
+    #if defined(VK_KHR_surface_maintenance1)
+        if (khrSurfaceMaintenance) {
+            extensions[extensionCount++] = VK_KHR_SURFACE_MAINTENANCE_1_EXTENSION_NAME;
+        }
+    #endif
     if (extSurfaceMaintenance) {
         extensions[extensionCount++] = VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME;
     }
@@ -635,14 +651,17 @@ void RendererImpl::selectPhysicalDevice() {
     vkGetPhysicalDeviceFeatures(physicalDevice, &features);
     extendedStorageFormats = features.shaderStorageImageExtendedFormats;
 
-    if (khrSurfaceMaintenance && deviceHasExtension(physicalDevice, VK_KHR_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME)) {
-        swapchainMaintenanceExtension = VK_KHR_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME;
-    } else if (extSurfaceMaintenance && deviceHasExtension(physicalDevice, VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME)) {
+    #if defined(VK_KHR_swapchain_maintenance1)
+        if (khrSurfaceMaintenance && deviceHasExtension(physicalDevice, VK_KHR_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME)) {
+            swapchainMaintenanceExtension = VK_KHR_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME;
+        } else
+    #endif
+    if (extSurfaceMaintenance && deviceHasExtension(physicalDevice, VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME)) {
         swapchainMaintenanceExtension = VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME;
     }
     if (swapchainMaintenanceExtension != nullptr) {
-        VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR maintenance{};
-        maintenance.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_KHR;
+        SwapchainMaintenanceFeatures maintenance{};
+        maintenance.sType = swapchainMaintenanceFeaturesType;
         VkPhysicalDeviceFeatures2 available{};
         available.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
         available.pNext = &maintenance;
@@ -676,9 +695,9 @@ void RendererImpl::createDevice() {
     }
     VkPhysicalDeviceFeatures features{};
     features.shaderStorageImageExtendedFormats = extendedStorageFormats;
-    VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR maintenance{};
+    SwapchainMaintenanceFeatures maintenance{};
     if (swapchainMaintenanceExtension != nullptr) {
-        maintenance.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_KHR;
+        maintenance.sType = swapchainMaintenanceFeaturesType;
         maintenance.swapchainMaintenance1 = VK_TRUE;
     }
     VkDeviceCreateInfo createInfo{};
@@ -1819,7 +1838,7 @@ bool RendererImpl::submitPresentFrame(u32 width, u32 height, FrameResources& fra
     checkVk(vkQueueSubmit(queue, 1, &submitInfo, frame.fence), "vkQueueSubmit");
     chain->initialized.mut(imageIndex) = true;
 
-    VkSwapchainPresentFenceInfoKHR presentFenceInfo{};
+    SwapchainPresentFenceInfo presentFenceInfo{};
     VkFence presentFence = VK_NULL_HANDLE;
     if (swapchainMaintenanceExtension != nullptr) {
         presentFence = chain->presentFences[imageIndex];
@@ -1827,7 +1846,7 @@ bool RendererImpl::submitPresentFrame(u32 width, u32 height, FrameResources& fra
             checkVk(vkWaitForFences(device, 1, &presentFence, VK_TRUE, UINT64_MAX), "vkWaitForFences");
             checkVk(vkResetFences(device, 1, &presentFence), "vkResetFences");
         }
-        presentFenceInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_KHR;
+        presentFenceInfo.sType = swapchainPresentFenceInfoType;
         presentFenceInfo.swapchainCount = 1;
         presentFenceInfo.pFences = &presentFence;
     }

--- a/third_party/plt/platform_wayland.cpp
+++ b/third_party/plt/platform_wayland.cpp
@@ -952,9 +952,11 @@ namespace {
     },
         .axis_value120 = pointerAxisSteps,
         .axis_relative_direction = [](void*, struct wl_pointer*, u32, u32) {},
-        .warp = [](void* data, struct wl_pointer*, wl_fixed_t x, wl_fixed_t y) {
-        pointerMotion(data, nullptr, 0, x, y);
-    },
+        #if defined(WL_POINTER_WARP_SINCE_VERSION)
+            .warp = [](void* data, struct wl_pointer*, wl_fixed_t x, wl_fixed_t y) {
+            pointerMotion(data, nullptr, 0, x, y);
+        },
+        #endif
     };
 
     void seatCapabilities(void* data, struct wl_seat*, u32 capabilities) {
@@ -1140,11 +1142,13 @@ namespace {
             [](void* data, struct zwp_text_input_v3*, u32) {
         ((PlatformImpl*)(data))->textInputDone();
     },
-        // Version 2 events; never delivered because the manager is bound at
-        // version 1.
-        .action = [](void*, struct zwp_text_input_v3*, u32, u32) {},
-        .language = [](void*, struct zwp_text_input_v3*, const char*) {},
-        .preedit_hint = [](void*, struct zwp_text_input_v3*, u32, u32, u32) {},
+        #if defined(ZWP_TEXT_INPUT_V3_ACTION_SINCE_VERSION)
+            // Version 2 events; never delivered because the manager is bound
+            // at version 1.
+            .action = [](void*, struct zwp_text_input_v3*, u32, u32) {},
+            .language = [](void*, struct zwp_text_input_v3*, const char*) {},
+            .preedit_hint = [](void*, struct zwp_text_input_v3*, u32, u32, u32) {},
+        #endif
     };
 
     u32 cursorShape(PointerIcon icon, u32 version) {

--- a/third_party/plt/tests/test.cpp
+++ b/third_party/plt/tests/test.cpp
@@ -235,7 +235,9 @@ namespace plt::test {
         .set_buffer_scale = [](wl_client*, wl_resource*, i32) {},
         .damage_buffer = [](wl_client*, wl_resource*, i32, i32, i32, i32) {},
         .offset = [](wl_client*, wl_resource*, i32, i32) {},
-        .get_release = nullptr,
+        #if defined(WL_SURFACE_GET_RELEASE_SINCE_VERSION)
+            .get_release = nullptr,
+        #endif
     };
 
     const struct wl_region_interface regionImplementation{
@@ -261,7 +263,9 @@ namespace plt::test {
         wl_resource* const region = wl_resource_create(client, &wl_region_interface, wl_resource_get_version(resource), id);
         wl_resource_set_implementation(region, &regionImplementation, nullptr, nullptr);
     },
-        .release = destroyResource,
+        #if defined(WL_COMPOSITOR_RELEASE_SINCE_VERSION)
+            .release = destroyResource,
+        #endif
     };
 
     const struct wl_pointer_interface pointerImplementation{
@@ -432,7 +436,9 @@ namespace plt::test {
         server->dataDevice = wl_resource_create(client, &wl_data_device_interface, wl_resource_get_version(resource), id);
         wl_resource_set_implementation(server->dataDevice, &dataDeviceImplementation, server, nullptr);
     },
-        .release = destroyResource,
+        #if defined(WL_DATA_DEVICE_MANAGER_RELEASE_SINCE_VERSION)
+            .release = destroyResource,
+        #endif
     };
 
     const struct zwp_primary_selection_source_v1_interface primarySourceImplementation{
@@ -658,9 +664,11 @@ namespace plt::test {
         server->textInputPendingEnabled = false;
         server->textInputPendingDisabled = false;
     },
-        .set_available_actions = [](wl_client*, wl_resource*, wl_array*) {},
-        .show_input_panel = [](wl_client*, wl_resource*) {},
-        .hide_input_panel = [](wl_client*, wl_resource*) {},
+        #if defined(ZWP_TEXT_INPUT_V3_SET_AVAILABLE_ACTIONS_SINCE_VERSION)
+            .set_available_actions = [](wl_client*, wl_resource*, wl_array*) {},
+            .show_input_panel = [](wl_client*, wl_resource*) {},
+            .hide_input_panel = [](wl_client*, wl_resource*) {},
+        #endif
     };
 
     const struct zwp_text_input_manager_v3_interface textInputManagerImplementation{


### PR DESCRIPTION
## Summary

Adds a native Ubuntu 24.04 amd64 `.deb` to GitHub releases while retaining the source and Darwin arm64 tarballs.

- `dev/build_deb.py` packages a clean source commit with commit-derived version metadata and ELF build ID. It derives direct shared-library dependencies with `dpkg-shlibdeps` instead of maintaining a manual dependency list.
- `dev/check_deb.py` verifies the payload, ownership and modes, embedded source identity, direct dependencies, dynamic loader resolution, and reported Shitty version.
- The release workflow resolves one tag and commit, builds Linux and macOS artifacts in parallel, requires the exact three-artifact set, creates a draft release, attests every artifact, and only then makes the release public.
- Pull requests and manual CI runs build, validate, apt-simulate, and lint the Ubuntu package.

## Ubuntu 24.04 source compatibility

Noble ships older generated Wayland protocol headers whose server-interface structs lack the newer request members initialized by the fake compositor. `wayland-scanner` emits the matching `WL_*_SINCE_VERSION` and `ZWP_*_SINCE_VERSION` macros alongside those fields, so `third_party/plt/tests/test.cpp` initializes no-op handlers only when the corresponding members exist. These are compile-time compatibility guards, not runtime assertions, and they do not skip test cases. This test-mock compatibility adds native Noble test support; `.deb` creation itself builds `st`.

Production Wayland listeners use analogous generated-version guards for newer callback members. The Vulkan renderer selects the KHR or EXT swapchain-maintenance types and guards KHR surface symbols according to the available headers. Linux Wayland, xkbcommon, realtime, math, and C++ runtime link requirements propagate through the production, test, and fuzz dependency graphs.

## Validation

The exact head `8f9b0898273b2b527fc4bd96c2a2ca3d94e26135` completed a clean Ubuntu 24.04 container build, package checker, apt installation simulation, and lintian error gate. Lintian emitted only `no-manual-page`.

The [fork validation run](https://github.com/ei-grad/shitty/actions/runs/30941105149) passed the Ubuntu package job. I downloaded its `.deb` and independently reran the package checker and apt simulation successfully. The fork coverage job is red only at the Codecov upload step because Codecov returns `Repository not found` for `ei-grad/shitty`; the coverage suite, report generation, and report artifact upload succeeded.

## Scope

The package targets Ubuntu 24.04 amd64 and links against the distribution Wayland, Vulkan, font, and Unicode libraries. It declares `Conflicts` and `Replaces` for Ubuntu’s `stterm` package because both install `/usr/bin/st`.