### PR TITLE
Apply cell snapping only to interactive resizes on macOS

### DIFF
--- a/third_party/plt/platform_cocoa.mm
+++ b/third_party/plt/platform_cocoa.mm
@@ -1467,6 +1467,12 @@ NSSize WindowImpl::willResize(NSSize frameSize) const {
         // visibly so with large cells.
         return frameSize;
     }
+    if (view != nil && !view.inLiveResize) {
+        // Non-interactive proposals come from window managers (AX resize,
+        // tiling WMs) and must land exactly; snapping leaves a dead strip
+        // in the assigned tile. Cell snapping is for user drags only.
+        return frameSize;
+    }
     const NSRect content = [window contentRectForFrameRect:NSMakeRect(0, 0, frameSize.width, frameSize.height)];
     const CGFloat scale = window.backingScaleFactor;
     u32 width = (u32)(max(1.0, content.size.width * scale) + 0.5);


### PR DESCRIPTION
Closes #55.

`willResize` snapped every proposal down to cell increments, including AX resizes
from tiling window managers, leaving a dead strip of up to one cell in the assigned
tile. Snap only during live (mouse-drag) resizes; non-interactive proposals land
exactly, matching the Wayland backend's behavior for maximized/fullscreen/tiled
configures and the existing fullscreen exemption on macOS.

Verified under AeroSpace: a managed window now fills its tile exactly (943px tall
where it previously snapped to 935). Unit tests pass (544).

🤖 Generated with [Claude Code](https://claude.com/claude-code)