### PR TITLE
macOS: an application menu, and Cmd+L to clear

### DIFF
--- a/composer.cpp
+++ b/composer.cpp
@@ -55,6 +55,7 @@ Composer::Composer(ObjPool* pool_, Brand& brand_)
     inputBindings->add(InputActions::CloseTab, &closeTabListeners);
     inputBindings->add(InputActions::PrevTab, &prevTabListeners);
     inputBindings->add(InputActions::NextTab, &nextTabListeners);
+    inputBindings->add(InputActions::Clear, &clearListeners);
     if (FontResolver* const resolver = createCoreTextFontResolver(*this)) {
         fontResolvers.pushBack(resolver);
     }

--- a/composer.h
+++ b/composer.h
@@ -121,4 +121,5 @@ struct Composer {
     stl::IntrusiveList closeTabListeners;
     stl::IntrusiveList prevTabListeners;
     stl::IntrusiveList nextTabListeners;
+    stl::IntrusiveList clearListeners;
 };

--- a/input_bindings.cpp
+++ b/input_bindings.cpp
@@ -48,6 +48,8 @@ namespace {
         {InputActions::PrevTab, {InputKey::Printable, InputSuper | InputShift, '['}},
         {InputActions::PrevTab, {InputKey::Printable, InputSuper | InputShift, '{'}},
         {InputActions::NextTab, {InputKey::Printable, InputSuper | InputShift, ']'}},
+        // Plain Ctrl+L stays the shell's, on both platforms.
+        {InputActions::Clear, {InputKey::Printable, InputSuper, 'l'}},
         {InputActions::NextTab, {InputKey::Printable, InputSuper | InputShift, '}'}},
 #elif defined(__linux__)
         {InputActions::Copy, {InputKey::Printable, InputControl | InputShift, 'c'}},
@@ -60,6 +62,7 @@ namespace {
         {InputActions::PrevTab, {InputKey::Printable, InputControl | InputShift, '['}},
         {InputActions::PrevTab, {InputKey::Printable, InputControl | InputShift, '{'}},
         {InputActions::NextTab, {InputKey::Printable, InputControl | InputShift, ']'}},
+        {InputActions::Clear, {InputKey::Printable, InputControl | InputShift, 'l', 'L'}},
         {InputActions::NextTab, {InputKey::Printable, InputControl | InputShift, '}'}},
 #else
     #error Unsupported platform

--- a/input_bindings.h
+++ b/input_bindings.h
@@ -29,6 +29,7 @@ enum class InputActions : u8 {
     CloseTab,
     PrevTab,
     NextTab,
+    Clear,
     Count,
 };
 

--- a/input_bindings_ut.cpp
+++ b/input_bindings_ut.cpp
@@ -166,6 +166,29 @@ STD_TEST_SUITE(InputBindings) {
         STD_INSIST(next.calls == 2);
     }
 
+    // Cmd+L is what a Mac user reaches for to clear the screen; the
+    // Linux habit is Ctrl+L, which the shell handles itself and which the
+    // terminal must keep forwarding untouched.
+    STD_TEST(ClearIsBoundWhereThePlatformExpectsIt) {
+        auto pool = ObjPool::fromMemory();
+        Composer& composer = *pool->make<Composer>(pool.mutPtr());
+        CountBinding clear;
+        composer.clearListeners.pushBack(&clear);
+
+#if defined(__APPLE__)
+        STD_INSIST(composer.inputBindings->key({InputKey::Printable, InputAction::Press, InputSuper, 0, 'l'}));
+        STD_INSIST(clear.calls == 1);
+        // Plain Ctrl+L stays the shell's business.
+        STD_INSIST(!composer.inputBindings->key({InputKey::Printable, InputAction::Press, InputControl, 0, 'l'}));
+        STD_INSIST(clear.calls == 1);
+#else
+        STD_INSIST(composer.inputBindings->key({InputKey::Printable, InputAction::Press, InputControl | InputShift, 0, 'l'}));
+        STD_INSIST(clear.calls == 1);
+        STD_INSIST(!composer.inputBindings->key({InputKey::Printable, InputAction::Press, InputControl, 0, 'l'}));
+        STD_INSIST(clear.calls == 1);
+#endif
+    }
+
     STD_TEST(ActionCanHaveMultiplePlatformBindings) {
         auto pool = ObjPool::fromMemory();
         Composer& composer = *pool->make<Composer>(pool.mutPtr());

--- a/plt_unit_tests
+++ b/plt_unit_tests
@@ -1,0 +1,1 @@
+.build/third_party/plt/plt_unit_tests

--- a/session.cpp
+++ b/session.cpp
@@ -92,6 +92,7 @@ namespace {
         CallSessionAction pastePrimaryAction{this, InputActions::PastePrimary};
         CallSessionAction pageUpAction{this, InputActions::PageUp};
         CallSessionAction pageDownAction{this, InputActions::PageDown};
+        CallSessionAction clearAction{this, InputActions::Clear};
     };
 }
 
@@ -187,6 +188,7 @@ SessionSet* SessionSet::create(Composer& composer) {
     composer.pastePrimaryListeners.pushBack(&sessions->pastePrimaryAction);
     composer.pageUpListeners.pushBack(&sessions->pageUpAction);
     composer.pageDownListeners.pushBack(&sessions->pageDownAction);
+    composer.clearListeners.pushBack(&sessions->clearAction);
     return sessions;
 }
 
@@ -230,6 +232,9 @@ void CallSessionAction::onListen(void*) {
             break;
         case InputActions::PageDown:
             terminal->pageDown();
+            break;
+        case InputActions::Clear:
+            terminal->clear();
             break;
         default:
             break;

--- a/third_party/plt/platform_cocoa.h
+++ b/third_party/plt/platform_cocoa.h
@@ -4,6 +4,8 @@
 #include "input.h"
 
 @class NSEvent;
+@class NSMenu;
+@class NSString;
 #endif
 
 namespace stl {
@@ -20,6 +22,14 @@ namespace plt {
     // handler, exposed so unit tests can drive it with synthesized events.
     KeyInput keyInputFromEvent(NSEvent* event, bool pressed);
     unsigned long cocoaWindowStyleMask(bool decorations);
+
+#ifdef __OBJC__
+    // The application menu. A Regular-policy app is given a menu bar
+    // whether or not it supplies one, so without this macOS shows an
+    // empty menu named after the app - and Cmd+Q, which is a menu key
+    // equivalent rather than a key event, has no item to fire.
+    NSMenu* cocoaBuildMainMenu(NSString* appName);
+#endif
     bool cocoaResizeUsesExactProposal(bool fullscreen, bool viewAvailable, bool liveResize);
 #endif
 }

--- a/third_party/plt/platform_cocoa.mm
+++ b/third_party/plt/platform_cocoa.mm
@@ -645,7 +645,7 @@ namespace {
         void run() override;
         void stop() override;
 
-        void ensureApplication();
+        void ensureApplication(StringView appName);
 
         PollerImpl* poller_ = nullptr;
         SmallObjAllocator* allocator_ = nullptr;
@@ -805,18 +805,48 @@ PlatformImpl::PlatformImpl(ObjPool& owner)
 {
 }
 
-void PlatformImpl::ensureApplication() {
+NSMenu* plt::cocoaBuildMainMenu(NSString* appName) {
+    NSMenu* const bar = [[NSMenu alloc] initWithTitle:@""];
+    NSMenuItem* const applicationItem = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
+    [bar addItem:applicationItem];
+
+    NSMenu* const application = [[NSMenu alloc] initWithTitle:appName];
+    [application addItemWithTitle:[@"About " stringByAppendingString:appName]
+                           action:@selector(orderFrontStandardAboutPanel:)
+                    keyEquivalent:@""];
+    [application addItem:[NSMenuItem separatorItem]];
+    [application addItemWithTitle:[@"Hide " stringByAppendingString:appName]
+                           action:@selector(hide:)
+                    keyEquivalent:@"h"];
+    NSMenuItem* const hideOthers = [application addItemWithTitle:@"Hide Others"
+                                                          action:@selector(hideOtherApplications:)
+                                                   keyEquivalent:@"h"];
+    hideOthers.keyEquivalentModifierMask = NSEventModifierFlagCommand | NSEventModifierFlagOption;
+    [application addItemWithTitle:@"Show All" action:@selector(unhideAllApplications:) keyEquivalent:@""];
+    [application addItem:[NSMenuItem separatorItem]];
+    [application addItemWithTitle:[@"Quit " stringByAppendingString:appName]
+                           action:@selector(terminate:)
+                    keyEquivalent:@"q"];
+    applicationItem.submenu = application;
+    return bar;
+}
+
+void PlatformImpl::ensureApplication(StringView appName) {
     if (applicationReady_) {
         return;
     }
     [NSApplication sharedApplication];
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    NSString* const name = appName.length() != 0
+        ? [[NSString alloc] initWithBytes:appName.data() length:appName.length() encoding:NSUTF8StringEncoding]
+        : [[NSProcessInfo processInfo] processName];
+    [NSApp setMainMenu:cocoaBuildMainMenu(name != nil ? name : @"shitty")];
     [NSApp finishLaunching];
     applicationReady_ = true;
 }
 
 Window* PlatformImpl::createWindow(ObjPool& owner, const WindowOptions& options) {
-    ensureApplication();
+    ensureApplication(options.appName);
     return owner.make<WindowImpl>(*this, options);
 }
 

--- a/third_party/plt/platform_cocoa_ut.mm
+++ b/third_party/plt/platform_cocoa_ut.mm
@@ -39,6 +39,33 @@ STD_TEST_SUITE(PlatformCocoaWindow) {
         STD_INSIST((borderless & NSWindowStyleMaskResizable) != 0);
     }
 
+    // A Regular-policy application gets a menu bar whether or not it
+    // supplies one, so an app with no NSMenu shows an empty "Shitty" menu
+    // when the pointer reaches the top of a fullscreen window. The same
+    // gap loses Cmd+Q, which is a menu key equivalent rather than a key
+    // event: with no item carrying it, nothing quits.
+    STD_TEST(MainMenuCarriesTheApplicationItems) {
+        @autoreleasepool {
+            NSMenu* const menu = cocoaBuildMainMenu(@"Shitty");
+            STD_INSIST(menu != nil);
+            STD_INSIST(menu.numberOfItems >= 1);
+
+            NSMenu* const application = [menu itemAtIndex:0].submenu;
+            STD_INSIST(application != nil);
+            STD_INSIST(application.numberOfItems > 0);
+
+            NSMenuItem* quit = nil;
+            for (NSMenuItem* item in application.itemArray) {
+                if ([item.keyEquivalent isEqualToString:@"q"]) {
+                    quit = item;
+                }
+            }
+            STD_INSIST(quit != nil);
+            STD_INSIST(quit.action == @selector(terminate:));
+            STD_INSIST((quit.keyEquivalentModifierMask & NSEventModifierFlagCommand) != 0);
+        }
+    }
+
     STD_TEST(WindowSubclassOverridesKeyEligibility) {
         const Class windowClass = NSClassFromString(@"PltWindow");
         STD_INSIST(windowClass != Nil);

--- a/vterm.cpp
+++ b/vterm.cpp
@@ -419,6 +419,7 @@ namespace {
         void flush() override;
         void copy() override;
         void paste(bool primary) override;
+        void clear() override;
         void key(InputKey key, VtModifier modifiers);
         void character(u8 byte, VtModifier modifiers);
         void sendBytes(StringView bytes, bool userInput) override;
@@ -2130,6 +2131,11 @@ void VtermImpl::copy() {
 
 void VtermImpl::paste(bool primary) {
     input.paste(primary);
+}
+
+void VtermImpl::clear() {
+    const u8 formFeed = 0x0c;
+    sendBytes(StringView(&formFeed, 1), true);
 }
 
 void VtermImpl::focus(bool focused) {

--- a/vterm.h
+++ b/vterm.h
@@ -161,6 +161,10 @@ struct Vterm {
     virtual void paste(bool primary) = 0;
     virtual void pageUp() = 0;
     virtual void pageDown() = 0;
+    // What Ctrl+L means, reached from a platform's own chord. The byte
+    // goes to the shell rather than clearing here, so the shell's own
+    // idea of a clear - prompt redraw and all - is what happens.
+    virtual void clear() = 0;
     virtual void feedPty(stl::StringView bytes) = 0;
     virtual void expose() = 0;
     virtual void sendBytes(stl::StringView bytes, bool userInput) = 0;


### PR DESCRIPTION
Three reports, two causes.

Fixes #70, fixes #71, fixes #72.

## The missing menu — #71 and #72

`platform_cocoa.mm` sets `NSApplicationActivationPolicyRegular` and never builds an `NSMenu`. A Regular-policy application is handed a menu bar whether or not it supplies one, so macOS shows an empty menu named after the app — which is what appears when the pointer reaches the top edge of a fullscreen window.

The same gap loses `Cmd+Q`. It is a menu *key equivalent*, not a key event, so it never reaches `keyDown:` at all; with no item carrying it, nothing quits. `performKeyEquivalent:` is not overridden anywhere either.

`cocoaBuildMainMenu` supplies the standard application items — About, Hide, Hide Others, Show All, Quit — titled from the window's own `appName`, falling back to the process name.

## Cmd+L — #70

It was simply not in the binding table. It joins as a `Clear` action, `Cmd+L` on macOS and `Ctrl+Shift+L` on Linux, matching where Copy and Paste already sit on each platform.

It sends the form feed to the shell rather than clearing the screen here, so what happens is the shell's own idea of a clear — prompt redraw included — rather than a terminal-side wipe that would leave the shell believing the cursor is elsewhere. Plain `Ctrl+L` keeps passing straight through on both platforms, which the test pins alongside the new chord.

## Tests

`MainMenuCarriesTheApplicationItems` asserts the Quit item exists, carries `Cmd`, and is wired to `terminate:` — it failed on the parent commit with `use of undeclared identifier 'cocoaBuildMainMenu'`. `ClearIsBoundWhereThePlatformExpectsIt` pins the new chord per platform and that plain `Ctrl+L` is still not consumed.

584 unit tests, 36 plt unit tests, and the black-box suite pass locally.

One thing worth flagging: `plt_unit_tests` on Darwin is not part of CI — the Darwin shards are gated behind the `darwin_tests` input — so the menu test runs locally and nowhere else. Happy to add it to the default matrix in a separate change if you want that coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
