### PR TITLE
Link liburing and xxhash when libstd detects them

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,15 @@ know: on macOS install LLVM from Homebrew and point the build at it
 (`export CC="$(brew --prefix llvm)/bin/clang"`, same for `CXX` with
 `clang++`). Every build requires:
 
-- Python 3, Ragel 6, and `glslangValidator`;
+- Python 3, Ragel 6 or 7, and `glslangValidator`;
 - librsvg (`rsvg-convert`), which renders the icon at build time;
 - pkg-config;
 - utf8proc 2.9 or newer;
 - POSIX threads and PTY support.
+
+Either Ragel generation works. Ragel 7 dropped the `-x` flag that
+`check_parser_totality.py` needs, so under it that check is skipped; the
+generated parser is the same either way.
 
 The exact `libstd` revision used by Shitty is bundled in
 `third_party/libstd` and built as part of the same graph.
@@ -114,6 +118,11 @@ The exact `libstd` revision used by Shitty is bundled in
 Linux additionally requires FreeType, HarfBuzz, Wayland client headers,
 xkbcommon, `wayland-scanner`, and Vulkan headers and loader. macOS requires
 SPIRV-Cross and uses CoreText, Cocoa, Metal, and IOSurface from the system SDK.
+
+liburing and xxhash are optional and need no configuration: `libstd`
+detects their headers and the build links whatever they turn on, giving
+an io_uring reactor and a faster hash where they are installed. rapidhash
+is header-only and supersedes xxhash when present.
 
 Brotli and simdutf are optional: Brotli only satisfies FreeType's
 static-link dependency chain where that applies, and simdutf 6.5 or

--- a/build
+++ b/build
@@ -861,6 +861,11 @@ class BuildContext:
             # Appended past the imported link line, after the archives it
             # references; static resolution order stays correct.
             root.commands[-1].append(dep.output)
+            # The libraries the dep resolves against follow it for the same
+            # reason. The imported graph never saw this dependency, so it
+            # cannot have asked for them, and only CFLAGS, CXXFLAGS and
+            # CPPFLAGS reach an import through the environment.
+            root.commands[-1].extend(self._link_flags([dep]))
             root.deps.append(dep.root)
 
         imported_nodes = self._register_imported_nodes(graph, [root])

--- a/build.py
+++ b/build.py
@@ -179,13 +179,48 @@ embedded_path_flags = [
 ]
 
 
+# libstd picks its backends with __has_include, so which libraries the
+# archive needs at link time depends on the headers this machine has. An
+# imported graph exports outputs, not flags, so nothing carries them over
+# the boundary: the importer has to run the same probe and ask for them
+# itself, the way the Linux backend does above.
+def have_header(header: str) -> bool:
+    probe = f"#if !__has_include(<{header}>)\n#error missing\n#endif\n"
+    try:
+        subprocess.run(
+            [os.environ.get("CXX", "c++"), *build.cppflags, "-E", "-x", "c++", "-"],
+            input=probe,
+            text=True,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return False
+    return True
+
+libstd_backends = []
+# std/thr/io_uring.cpp, pulled in by the reactor every binary starts.
+if have_header("liburing.h"):
+    libstd_backends.append("-luring")
+# std/str/hash.cpp prefers rapidhash, which is header-only, and falls
+# back to xxhash before its own FNV-1a. Mirror that order exactly:
+# probing for xxhash alone would link a library nothing calls.
+if not have_header("rapidhash.h") and have_header("xxhash.h"):
+    libstd_backends.append("-lxxhash")
+# The TLS and DNS backends are detected the same way but stay out of this
+# list: nothing here references them, so the linker never pulls their
+# archive members in and their libraries would be dead weight.
+
 libstd = import_build(std_build, "libstd.a", extra_cflags=embedded_path_flags)
+libstd.ldflags += libstd_backends
 libstd_external_clock = import_build(
     std_build,
     "libstd_external_clock.a",
     extra_cflags=embedded_path_flags,
     extra_cppflags=["-DSTL_EXTERNAL_MONOTONIC_NOW_US=1"],
 )
+libstd_external_clock.ldflags += libstd_backends
 
 
 if "-lplt" in build.ldflags:


### PR DESCRIPTION

## Problem

`./build` fails at link time on any Linux distribution shipping the liburing and
xxhash development headers:

```
libstd.a(io_uring.cpp.o): undefined reference to `io_uring_queue_init_params'
libstd.a(io_uring.cpp.o): undefined reference to `io_uring_submit'
libstd.a(hash.cpp.o):     undefined reference to `XXH3_64bits'
```

Reproduced on Arch with `liburing 2.15` and `xxhash 0.8.3`; the same applies to
Fedora and Debian/Ubuntu once `liburing-dev` and `libxxhash-dev` are installed.

`libstd` selects its backends with `__has_include`:

- `third_party/libstd/std/thr/io_uring.cpp:23` — `<liburing.h>`
- `third_party/libstd/std/str/hash.cpp:5-9` — `<rapidhash.h>`, else `<xxhash.h>`

Where those headers exist the code compiles in, but nothing puts `-luring` or
`-lxxhash` on the link line. `st`, `pt`, and both `plt` test binaries fail.

## Why CI does not catch it

The jobs build through `nix build`, and `flake.nix` lists neither library in
`buildInputs`. Inside the sandbox both `__has_include` checks fail, the built-in
fallbacks compile instead, and those need no libraries. The break is invisible to
CI and hits everyone building outside Nix.

## Two commits

### 1. Carry an injected dependency's link flags into the imported graph

`import_build` appends a dependency's archive to the imported program's link
line, but not the libraries that archive resolves against. The imported graph
cannot supply them itself: it never saw the dependency, and an import inherits
only `CFLAGS`, `CXXFLAGS` and `CPPFLAGS` through the environment — see the flag
loop in `_load_imported_graph`.

That gap is what breaks `plt_unit_tests` and `plt_wayland_integration_tests`,
which live inside the `third_party/plt` graph and link the `libstd.a` the root
graph hands them. Appending `_link_flags([dep])` behind the archive puts the
libraries where static resolution needs them, transitively.

On its own this commit changes nothing — no target declares such flags yet.

### 2. Link the libstd backends the headers on this machine turn on

`have_header()` runs the same `__has_include` test the sources run, through
`$CXX` with the build's own cppflags, and the result is appended to
`libstd.ldflags`. `_link_flags` walks it out to `st`, `pt`, the test binaries,
and — via the first commit — into the `plt` graph. This is the shape of the
existing `-lrt` workaround at `build.py:168-171`, whose comment already names
this class of problem.

Two deliberate scope decisions:

- rapidhash is probed first and short-circuits xxhash, mirroring `hash.cpp`'s own
  `#elif` order. Probing for xxhash alone would link a library nothing calls on a
  machine that has rapidhash.
- The TLS (`ssl_socket.cpp`) and DNS (`ares.cpp`) backends are detected the same
  way but stay out. Nothing here references them, so the linker never pulls those
  archive members in — verified on a machine carrying both `<openssl/ssl.h>` and
  `<ares.h>`, which links clean. Their libraries would be unused runtime
  dependencies on a terminal emulator.

With no headers found the list is empty and `libstd.ldflags += []` is a no-op, so
the Nix path is byte-for-byte unchanged.

README also claimed `Ragel 6` while `ragel_major()` in `build.py` has accepted 6
and 7 since it learned the `-G0` mapping — the stated requirement sends people
off to build Ragel 6 by hand. Fixed, with a note that `check_parser_totality.py`
is skipped under Ragel 7, which dropped `-x`. liburing and xxhash are documented
as optional beside the Brotli and simdutf paragraph.

## Testing

Arch Linux, GCC 16.1.1 (`/usr/bin/c++`), Ragel 7.0.4, liburing 2.15,
xxhash 0.8.3, Mesa/Intel Vulkan under a live Wayland session.

- `./build` with no `LDFLAGS` set links clean. `ldd` reports `liburing.so.2` and
  `libxxhash.so.0` on `st`, `pt` and both `plt` test binaries.
- `./build -k test`: 1835/1835 nodes, exit 0 — 1708 PASS, 62 XFAIL, 0 FAIL.
- The upstream vttest profile, `tests/vttest.py` driving `st_test`, passes
  against vttest 20251205.
- `have_header` resolves as the sources do: true for `liburing.h` and
  `xxhash.h`, false for `rapidhash.h` and for a header that does not exist.

The Nix builds are not exercised here. With neither header visible the probe
yields an empty list, so both changes reduce to no-ops on that path.

## Follow-up, not in this PR

The detection still lives in two places — `__has_include` in the sources and the
probe in `build.py`. Collapsing them would mean letting an imported graph export
its own link requirements upward, a larger change to the export protocol in
`serialize_graph` than this fix. `third_party/libstd/BUILD.md` already documents
the header-to-library table for all six optional backends, so the knowledge is
written down; it just cannot cross the graph boundary yet.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
