### PR TITLE
Ignore what a test run leaves in the source root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,10 @@
 __pycache__/
 .codegraph/
 /plt_tests
+/plt_unit_tests
+/plt_wayland_integration_tests
 /test_suite_prod_parser
 /third_party/plt/plt_unit_tests
 /third_party/plt/plt_wayland_integration_tests
 /toml_dump
+/bounce*.log


### PR DESCRIPTION
A `./build test` run leaves six untracked files in the source root.

**The two `plt` test binaries.** Building `plt_unit_tests` or
`plt_wayland_integration_tests` from the parent graph publishes their symlinks in
the source root, exactly as `/plt_tests` beside them in `.gitignore` already
anticipates — those two were simply missed.

The existing `/third_party/plt/...` entries are a different case and stay: they
cover a standalone plt build, whose own `.gitignore` stops at the build
directories.

**Four `bounce*.log` files.** `tests/xterm_vttests/upstream/bounce.sh:38` writes
`bounce${LOG}.log` into the working directory whenever `WINDOWID` is set, and the
suite runs it from the source root. The vendored script is left untouched.

Verified with `git check-ignore -v` against all six names, and that
`/third_party/plt/plt_unit_tests` still matches.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
