### PR TITLE
Add core_perf, a whole-core throughput probe

### DIFF
--- a/bin/core_perf/main.cpp
+++ b/bin/core_perf/main.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 Shitty team
+ * MIT licensed
+ * See the file LICENSE.MIT for the full license.
+ */
+
+// Feeds a corpus file through the complete headless VT core - parser,
+// vterm and screen, with the frame consumed each time - and reports the
+// throughput. Unlike parser_perf, which drives the FSM with no-op
+// callbacks, this measures the work an embedder actually pays for.
+//
+// Usage: core_perf <corpus-path> [runs] [save-lines]
+//
+// save-lines matters: the default Options carries 0, so a run left at
+// the default measures a terminal with no scrollback to retain.
+
+#include "composer.h"
+#include "num.h"
+#include "options.h"
+#include "vterm_headless.h"
+
+#include <std/ios/sys.h>
+#include <std/ios/output.h>
+#include <std/mem/obj_pool.h>
+#include <std/str/view.h>
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+using namespace stl;
+
+namespace {
+    // One PTY read's worth per feed, so the batching matches what a host
+    // draining a pty would hand over.
+    constexpr size_t chunkBytes = 64 * 1024;
+
+    static double now() {
+        timespec ts;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        return (double)(ts.tv_sec) + (double)(ts.tv_nsec) / 1e9;
+    }
+
+    static u8* readFile(const char* path, size_t& length) {
+        const int fd = open(path, O_RDONLY);
+        if (fd < 0) {
+            return nullptr;
+        }
+        struct stat info;
+        if (fstat(fd, &info) < 0) {
+            close(fd);
+            return nullptr;
+        }
+        length = (size_t)(info.st_size);
+        u8* const data = (u8*)(malloc(length));
+        size_t taken = 0;
+        while (taken < length) {
+            const ssize_t got = read(fd, data + taken, length - taken);
+            if (got <= 0) {
+                break;
+            }
+            taken += (size_t)(got);
+        }
+        close(fd);
+        length = taken;
+        return data;
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        sysE << StringView(u8"usage: core_perf <corpus-path> [runs] [save-lines]") << endL;
+        return 2;
+    }
+    i64 runs = 3;
+    if (argc > 2 && (!parseI64(StringView(argv[2]), runs) || runs <= 0)) {
+        sysE << StringView(u8"usage: core_perf <corpus-path> [runs] [save-lines]") << endL;
+        return 2;
+    }
+    i64 saveLines = 0;
+    if (argc > 3 && (!parseI64(StringView(argv[3]), saveLines) || saveLines < 0 || saveLines > 50000)) {
+        sysE << StringView(u8"usage: core_perf <corpus-path> [runs] [save-lines]") << endL;
+        return 2;
+    }
+
+    size_t length = 0;
+    u8* const corpus = readFile(argv[1], length);
+    if (corpus == nullptr || length == 0) {
+        sysE << StringView(u8"core_perf: cannot read corpus") << endL;
+        return 2;
+    }
+
+    double best = 0.0;
+    for (i64 run = 0; run < runs; ++run) {
+        // A fresh terminal per run: scrollback accumulated by an earlier
+        // run would otherwise pay for the next one's allocations.
+        ObjPool::Ref pool = ObjPool::fromMemory();
+        Composer* const composer = pool->make<Composer>(pool.mutPtr());
+        // Composer builds a default Options; swap in one carrying the
+        // requested scrollback, since the default retains none.
+        Options* const options = pool->make<Options>();
+        options->saveLines = (u16)(saveLines);
+        composer->opts = options;
+        VtermHeadless* const host = VtermHeadless::create(*composer, nullptr, nullptr);
+
+        const double start = now();
+        size_t fed = 0;
+        while (fed < length) {
+            size_t take = length - fed;
+            if (take > chunkBytes) {
+                take = chunkBytes;
+            }
+            host->feed(corpus + fed, take);
+            fed += take;
+        }
+        const double elapsed = now() - start;
+        if (best == 0.0 || elapsed < best) {
+            best = elapsed;
+        }
+    }
+
+    const double mebibytes = (double)(length) / (double)(1 << 20);
+    sysO << StringView(u8"core_perf ") << StringView(argv[1]) << StringView(u8": ")
+         << (i64)(length) << StringView(u8" bytes in ") << (i64)(best * 1e6)
+         << StringView(u8" us, ") << (i64)(mebibytes / best)
+         << StringView(u8" MiB/s, save_lines=") << saveLines << endL;
+    free(corpus);
+    return 0;
+}

--- a/build.py
+++ b/build.py
@@ -907,6 +907,16 @@ parser_perf = program(
 )
 
 
+# The whole VT core - parser, vterm and screen - driven headlessly over
+# a corpus file; the throughput an embedder would actually see.
+core_perf = program(
+    name="core_perf",
+    output="$(B)/core_perf",
+    srcs=["$(S)/bin/core_perf/main.cpp"],
+    deps=[libshitty, libstd],
+)
+
+
 # Each shard is an independent graph node with its own hard timeout.
 test_group_count = 20
 python_test_inputs = [
@@ -918,6 +928,7 @@ python_test_inputs = [
     "$(S)/lib/shitty/heap_profile.cpp",
     "$(S)/bin/main_fuzz/main.cpp",
     "$(S)/bin/parser_perf/main.cpp",
+    "$(S)/bin/core_perf/main.cpp",
     *build.glob("$(S)/lib/shitty/*_ut.cpp"),
     *build.glob("$(S)/tst/*.py"),
     *build.glob("$(S)/tst/*.md"),


### PR DESCRIPTION
## Problem

`parser_perf` measures the FSM with no-op callbacks. That is the right shape for
what it is, but it deliberately excludes screen writes, scrollback and reflow —
the parts most likely to regress, and the parts anything driving the core
actually pays for. Nothing measures the core as a whole, so a change that leaves
the parser untouched and doubles the cost of a screen write is invisible until it
shows up in the GUI numbers, mixed in with rendering.

## Change

`core_perf` feeds a corpus file through `VtermHeadless` in 64 KiB chunks — one
PTY read's worth, matching how a host hands bytes over — and reports the best
wall time of N runs:

```text
$ core_perf corpora/sgr.bin 3 10000
core_perf corpora/sgr.bin: 16777216 bytes in 205926 us, 77 MiB/s, save_lines=10000
```

A corpus file rather than generated input, so the same bytes replay across builds,
across machines, and against other emulators.

Each run builds a fresh terminal: scrollback retained by an earlier run would
otherwise pay for the next one's allocations and flatter later runs.

`save-lines` is an explicit argument rather than a constant because the `Options`
that `Composer` default-constructs carries `0`. A run left at the default measures
a terminal with no history to retain, which for the ASCII path is roughly a 3x
difference — easy to report by accident.

## Numbers from it

Best of 3, 16 MiB corpora, 80x24, AMD Ryzen 7 4800H, GCC 16.1.1:

| corpus | save_lines=0 | save_lines=10000 |
|---|---|---|
| printable ASCII | 1187 MiB/s | 385 MiB/s |
| SGR-heavy | 80 MiB/s | 77 MiB/s |
| mixed Unicode + emoji | 50 MiB/s | 47 MiB/s |
| random bytes | 41 MiB/s | 38 MiB/s |

The spread across corpora is the useful part: the bulk ASCII path is an order of
magnitude away from everything else, so a single "throughput" figure hides which
path a change actually moved.

## Tests

No new tests — it is a probe, not a behaviour change, and it builds only as its
own target. Ran locally after the change: `production_surface`,
`test_build_metadata`, `test_options` — 41 passed, 2 skipped.

`bin/core_perf/main.cpp` is added to `python_test_inputs` alongside the existing
`parser_perf` and `main_fuzz` sources, for consistency with how those are tracked.

I could not run `dev/style.py` — no `clang-format` on this machine — so the
formatting is by hand against the surrounding files. Happy to fix whatever it
flags.
