### PR TITLE
Link the shared facade against libstd's probed backends

### DIFF
--- a/build.py
+++ b/build.py
@@ -1018,6 +1018,10 @@ if linux:
             plt_headless.output,
             libstd_pic.output,
             *simdutf.ldflags,
+            # libstd's hash, atomic and io_uring backends are probed, so the
+            # shared link needs whatever the probe chose; --no-undefined
+            # rejects the library outright without them.
+            *libstd_backends,
         ]],
         descr="SO",
         color="magenta",


### PR DESCRIPTION
## Problem

`./build so` fails on any host where libstd's probes select a system library:

```text
hash.cpp:30: undefined reference to `XXH3_64bits'
collect2: error: ld returned 1 exit status
```

`libstd_backends` is assembled by probing — `-lxxhash` when `xxhash.h` is present
and `rapidhash.h` is not, plus `-latomic` and `-luring` where those are needed —
and `build.py` hands it to `libstd`, `libstd_external_clock` and `libstd_pic`
alike. The `so` target forwards `simdutf.ldflags` but not `libstd_backends`, so
`-Wl,--no-undefined` rejects the library.

This is Fedora 44 out of the box (`xxhash-devel`, no `rapidhash.h`). CI does not
see it because its toolchain probes to a different backend. `./build a` is
unaffected in the sense that it succeeds — but the merged archive necessarily
leaves those system symbols undefined too, so a consumer of the static library
needs the same flags on its own link line.

## Change

Forward `libstd_backends` to `link_shared.py` next to `simdutf.ldflags`.

Afterwards `libshitty_vt.so` links, and:

```text
$ nm -D --defined-only .build/libshitty_vt.so | grep -c ' T '
8
$ readelf -d .build/libshitty_vt.so | grep NEEDED
  libatomic.so.1  liburing.so.2  libxxhash.so.0  libstdc++.so.6  libm.so.6 ...
```

All three probed backends were missing, not only xxhash — so the same failure
would hit a host that needed `-latomic` or `-luring`.

## Verification

Exercised as an actual out-of-tree consumer: a C file including `shitty_vt.h` and
linking only `libshitty_vt.so`, no other shitty objects.

```text
  r0 c0 w1 fg=0000AA U+0068
  r0 c1 w1 fg=0000AA U+0069
  r0 c3 w2 fg=FFFFFF U+65E5
  r0 c6 w2 fg=FFFFFF U+1F469 U+200D U+1F4BB
cursor r0 c8 visible=1 modes=0x120
```

SGR colour resolves, the wide cell reports `width 2` and its continuation is
skipped, and the ZWJ sequence arrives as one width-2 cell carrying all three
codepoints.

`test_embed_example` — 37 passed.

## One question

Since the static archive cannot bundle system libraries either, a consumer of
`libshitty_vt.a` needs `-lxxhash -latomic -luring -lpthread -lm` — whichever the
build probed — and has no way to discover which. Worth emitting the chosen flags
somewhere consumable (a generated `.pc`, or a line in the build output)? Happy to
send that separately if you want it; I did not want to guess the shape.
