### PR TITLE
Read scrollback rows by index through the facade

### DIFF
--- a/bin/example/main.c
+++ b/bin/example/main.c
@@ -78,6 +78,14 @@ static void on_bell(void* user) {
     printf("bell\n");
 }
 
+/* Collects one row's text, ignoring the row number the callback repeats. */
+static void collect_row(void* user, uint16_t row, uint16_t column, const shitty_vt_cell* cell) {
+    struct grid* const target = (struct grid*)user;
+    (void)row;
+    collect_cell(user, 0, column, cell);
+    (void)target;
+}
+
 int main(int argc, char** argv) {
     uint16_t columns = 80;
     uint16_t rows = 24;
@@ -85,6 +93,7 @@ int main(int argc, char** argv) {
     const char* path = NULL;
     int scroll = 0;
     long scroll_to = -1;
+    int dump_rows = 0;
     if (argc >= 4) {
         columns = (uint16_t)atoi(argv[1]);
         rows = (uint16_t)atoi(argv[2]);
@@ -95,6 +104,8 @@ int main(int argc, char** argv) {
         /* An absolute offset to settle on afterwards; negative leaves the
          * view where the relative scroll put it. */
         scroll_to = argc >= 7 ? atol(argv[6]) : -1;
+        /* Print every addressable row, history first, after the grid. */
+        dump_rows = argc >= 8 ? atoi(argv[7]) : 0;
     } else if (argc == 2) {
         path = argv[1];
     }
@@ -180,10 +191,38 @@ int main(int argc, char** argv) {
     }
 
     printf(
-        "scrollback: offset=%u history=%u\n",
+        "scrollback: offset=%u history=%u total=%u\n",
         shitty_vt_scroll_offset(vt),
-        shitty_vt_history_rows(vt)
+        shitty_vt_history_rows(vt),
+        shitty_vt_total_rows(vt)
     );
+
+    if (dump_rows) {
+        const uint32_t total = shitty_vt_total_rows(vt);
+        uint32_t index;
+        struct grid one;
+        one.columns = columns;
+        one.rows = 1;
+        one.text = calloc(columns, CELL_TEXT_CAP);
+        if (one.text == NULL) {
+            shitty_vt_free(vt);
+            return 1;
+        }
+        for (index = 0; index < total; ++index) {
+            uint16_t column;
+            for (column = 0; column < columns; ++column) {
+                one.text[column * CELL_TEXT_CAP] = ' ';
+                one.text[column * CELL_TEXT_CAP + 1] = '\0';
+            }
+            shitty_vt_row_cells(vt, index, collect_row, &one);
+            printf("row %u:", index);
+            for (column = 0; column < columns; ++column) {
+                fputs(one.text + column * CELL_TEXT_CAP, stdout);
+            }
+            fputc('\n', stdout);
+        }
+        free(one.text);
+    }
 
     shitty_vt_free(vt);
     return 0;

--- a/bin/example/main.c
+++ b/bin/example/main.c
@@ -5,7 +5,8 @@
  */
 /* The C embedding example: feed a recorded byte stream into a
  * shitty_vt, then print what an embedder can read back - the grid as
- * UTF-8 text, the cursor, the mode bits and the terminal's replies.
+ * UTF-8 text, the cursor, the mode bits, the terminal's replies and
+ * the scrollback position.
  *
  * Usage: example [columns rows save_lines] [stream-file]
  * With no file the stream is read from stdin. */
@@ -82,11 +83,14 @@ int main(int argc, char** argv) {
     uint16_t rows = 24;
     uint16_t save_lines = 0;
     const char* path = NULL;
+    int scroll = 0;
     if (argc >= 4) {
         columns = (uint16_t)atoi(argv[1]);
         rows = (uint16_t)atoi(argv[2]);
         save_lines = (uint16_t)atoi(argv[3]);
         path = argc >= 5 ? argv[4] : NULL;
+        /* Rows to scroll up into the scrollback before reading the grid. */
+        scroll = argc >= 6 ? atoi(argv[5]) : 0;
     } else if (argc == 2) {
         path = argv[1];
     }
@@ -117,6 +121,10 @@ int main(int argc, char** argv) {
     }
     if (input != stdin) {
         fclose(input);
+    }
+
+    if (scroll != 0) {
+        shitty_vt_scroll(vt, scroll);
     }
 
     struct grid grid;
@@ -165,6 +173,12 @@ int main(int argc, char** argv) {
         }
         fputc('\n', stdout);
     }
+
+    printf(
+        "scrollback: offset=%u history=%u\n",
+        shitty_vt_scroll_offset(vt),
+        shitty_vt_history_rows(vt)
+    );
 
     shitty_vt_free(vt);
     return 0;

--- a/bin/example/main.c
+++ b/bin/example/main.c
@@ -94,6 +94,7 @@ int main(int argc, char** argv) {
     int scroll = 0;
     long scroll_to = -1;
     int dump_rows = 0;
+    long new_save_lines = -1;
     if (argc >= 4) {
         columns = (uint16_t)atoi(argv[1]);
         rows = (uint16_t)atoi(argv[2]);
@@ -106,6 +107,9 @@ int main(int argc, char** argv) {
         scroll_to = argc >= 7 ? atol(argv[6]) : -1;
         /* Print every addressable row, history first, after the grid. */
         dump_rows = argc >= 8 ? atoi(argv[7]) : 0;
+        /* A history cap to apply after feeding; negative keeps the one
+         * the terminal was built with. */
+        new_save_lines = argc >= 9 ? atol(argv[8]) : -1;
     } else if (argc == 2) {
         path = argv[1];
     }
@@ -136,6 +140,10 @@ int main(int argc, char** argv) {
     }
     if (input != stdin) {
         fclose(input);
+    }
+
+    if (new_save_lines >= 0) {
+        shitty_vt_set_save_lines(vt, (uint16_t)new_save_lines);
     }
 
     shitty_vt_scroll(vt, scroll);
@@ -196,6 +204,19 @@ int main(int argc, char** argv) {
         shitty_vt_history_rows(vt),
         shitty_vt_total_rows(vt)
     );
+
+    {
+        shitty_vt_memory memory;
+        shitty_vt_memory_usage(vt, &memory);
+        printf(
+            "memory: allocated_rows=%u capacity_rows=%u columns=%u cell_size=%u cell_bytes=%llu\n",
+            memory.allocated_rows,
+            memory.capacity_rows,
+            memory.columns,
+            memory.cell_size,
+            (unsigned long long)memory.cell_bytes
+        );
+    }
 
     if (dump_rows) {
         const uint32_t total = shitty_vt_total_rows(vt);

--- a/bin/example/main.c
+++ b/bin/example/main.c
@@ -84,6 +84,7 @@ int main(int argc, char** argv) {
     uint16_t save_lines = 0;
     const char* path = NULL;
     int scroll = 0;
+    long scroll_to = -1;
     if (argc >= 4) {
         columns = (uint16_t)atoi(argv[1]);
         rows = (uint16_t)atoi(argv[2]);
@@ -91,6 +92,9 @@ int main(int argc, char** argv) {
         path = argc >= 5 ? argv[4] : NULL;
         /* Rows to scroll up into the scrollback before reading the grid. */
         scroll = argc >= 6 ? atoi(argv[5]) : 0;
+        /* An absolute offset to settle on afterwards; negative leaves the
+         * view where the relative scroll put it. */
+        scroll_to = argc >= 7 ? atol(argv[6]) : -1;
     } else if (argc == 2) {
         path = argv[1];
     }
@@ -123,8 +127,9 @@ int main(int argc, char** argv) {
         fclose(input);
     }
 
-    if (scroll != 0) {
-        shitty_vt_scroll(vt, scroll);
+    shitty_vt_scroll(vt, scroll);
+    if (scroll_to >= 0) {
+        shitty_vt_scroll_to(vt, (uint32_t)scroll_to);
     }
 
     struct grid grid;

--- a/build.py
+++ b/build.py
@@ -1018,6 +1018,10 @@ if linux:
             plt_headless.output,
             libstd_pic.output,
             *simdutf.ldflags,
+            # libstd's hash, atomic and io_uring backends are probed, so the
+            # shared link needs whatever the probe chose; --no-undefined
+            # rejects the library outright without them.
+            *libstd_backends,
         ]],
         descr="SO",
         color="magenta",

--- a/core_perf
+++ b/core_perf
@@ -1,0 +1,1 @@
+.build/core_perf

--- a/example
+++ b/example
@@ -1,0 +1,1 @@
+.build/example

--- a/lib/embed/shitty_vt.cpp
+++ b/lib/embed/shitty_vt.cpp
@@ -560,6 +560,24 @@ void shitty_vt_each_cell(shitty_vt* vt, shitty_vt_cell_fn fn, void* user) {
     vt->terminal->consume();
 }
 
+uint32_t shitty_vt_scroll(shitty_vt* vt, int32_t rows) {
+    return vt->terminal->scrollView(rows);
+}
+
+uint32_t shitty_vt_scroll_to(shitty_vt* vt, uint32_t offset) {
+    return vt->terminal->scrollViewTo(offset);
+}
+
+uint32_t shitty_vt_scroll_offset(const shitty_vt* vt) {
+    const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
+    return update != nullptr ? update->viewOffset : 0;
+}
+
+uint32_t shitty_vt_history_rows(const shitty_vt* vt) {
+    const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
+    return update != nullptr ? update->historyRows : 0;
+}
+
 shitty_vt_cursor shitty_vt_cursor_state(const shitty_vt* vt) {
     shitty_vt_cursor result{};
     const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));

--- a/lib/embed/shitty_vt.cpp
+++ b/lib/embed/shitty_vt.cpp
@@ -576,17 +576,27 @@ uint32_t shitty_vt_scroll_to(shitty_vt* vt, uint32_t offset) {
 
 uint32_t shitty_vt_scroll_offset(const shitty_vt* vt) {
     const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
-    return update != nullptr ? update->viewOffset : 0;
+    if (update == nullptr || update->shapes == nullptr) {
+        return 0;
+    }
+    return update->shapes->info().viewOffset;
 }
 
 uint32_t shitty_vt_history_rows(const shitty_vt* vt) {
     const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
-    return update != nullptr ? update->historyRows : 0;
+    if (update == nullptr || update->shapes == nullptr) {
+        return 0;
+    }
+    return update->shapes->info().historyRows;
 }
 
 uint32_t shitty_vt_total_rows(const shitty_vt* vt) {
     const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
-    return update != nullptr ? update->historyRows + vt->geometry.rows : 0;
+    if (update == nullptr || update->shapes == nullptr) {
+        return 0;
+    }
+    const ScreenInfo info = update->shapes->info();
+    return info.historyRows + info.rows;
 }
 
 void shitty_vt_row_cells(shitty_vt* vt, uint32_t index, shitty_vt_cell_fn fn, void* user) {
@@ -597,18 +607,46 @@ void shitty_vt_row_cells(shitty_vt* vt, uint32_t index, shitty_vt_cell_fn fn, vo
     if (update == nullptr || update->shapes == nullptr) {
         return;
     }
-    if (index >= update->historyRows + vt->geometry.rows) {
+    Screen* const screen = update->shapes;
+    const ScreenInfo info = screen->info();
+    if (index >= info.historyRows + info.rows) {
         return;
     }
-    Screen* const screen = update->shapes;
     // Logical row 0 is the top of the live screen and the history runs
     // negative from there, so an oldest-first index sits historyRows
     // above it. viewRow subtracts the current offset, so add it back and
     // the read is independent of where the user has scrolled.
-    const i32 logical = (i32)(index) - (i32)(update->historyRows);
-    const i32 view = logical + (i32)(update->viewOffset);
+    const i32 logical = (i32)(index) - (i32)(info.historyRows);
+    const i32 view = logical + (i32)(info.viewOffset);
     emitRow(vt, update->colors, screen->viewRow(view), (u16)(index), fn, user);
     vt->terminal->consume();
+}
+
+void shitty_vt_memory_usage(const shitty_vt* vt, shitty_vt_memory* out) {
+    if (out == nullptr) {
+        return;
+    }
+    *out = shitty_vt_memory{};
+    const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
+    if (update == nullptr || update->shapes == nullptr) {
+        return;
+    }
+    const ScreenInfo info = update->shapes->info();
+    out->allocated_rows = info.materializedRows;
+    out->capacity_rows = (u32)(info.rows) + info.saveLines;
+    out->columns = info.columns;
+    out->cell_size = (u32)(sizeof(TerminalCell));
+    out->cell_bytes = (u64)(info.materializedRows) * info.columns * sizeof(TerminalCell);
+}
+
+void shitty_vt_set_save_lines(shitty_vt* vt, uint16_t save_lines) {
+    if (vt->config.saveLines == save_lines) {
+        return;
+    }
+    vt->config.saveLines = save_lines;
+    // The terminal re-reads the configuration and rebuilds whatever the
+    // change invalidated, which for this setting is the primary screen.
+    vt->terminal->configChanged();
 }
 
 shitty_vt_cursor shitty_vt_cursor_state(const shitty_vt* vt) {

--- a/lib/embed/shitty_vt.cpp
+++ b/lib/embed/shitty_vt.cpp
@@ -455,6 +455,43 @@ namespace {
         attributes |= cell.overline ? SHITTY_VT_ATTR_OVERLINE : 0;
         return attributes;
     }
+
+    // One row of cells handed to an embedder's callback. The row number
+    // is passed through rather than derived, so a caller reading the
+    // history by index reports that index.
+    static void emitRow(shitty_vt* vt, const TerminalColors* colors, const ScreenRowRef& source, u16 row, shitty_vt_cell_fn fn, void* user) {
+        if (source.cells == nullptr) {
+            return;
+        }
+        CellExtraStore* const extras = vt->extras.store;
+        for (u16 column = 0; column < vt->geometry.columns; ++column) {
+            const TerminalCell& cell = source.cells[column];
+            if (cell.dwidth_cont) {
+                continue;
+            }
+            shitty_vt_cell out{};
+            u32 single = 0;
+            if (cell.hasExtra()) {
+                const GraphemeView grapheme = extras->grapheme(cell);
+                out.grapheme = grapheme.data();
+                out.grapheme_len = grapheme.count;
+            } else if (cell.uc_pt != 0) {
+                single = cell.uc_pt;
+                out.grapheme = &single;
+                out.grapheme_len = 1;
+            }
+            if (colors != nullptr) {
+                out.foreground = colors->resolveForeground(cell).packed();
+                out.background = colors->resolveBackground(cell).packed();
+                out.underline_color = colors->resolve(extras->underlineColor(cell)).packed();
+            }
+            out.attributes = (u16)(packAttributes(cell));
+            out.underline_style = (u8)(cell.underline_style);
+            out.width = cell.dwidth ? 2 : 1;
+            fn(user, row, column, &out);
+        }
+    }
+
 }
 
 static constexpr shitty_vt_callbacks noCallbacks{};
@@ -523,39 +560,8 @@ void shitty_vt_each_cell(shitty_vt* vt, shitty_vt_cell_fn fn, void* user) {
         return;
     }
     Screen* const screen = update->shapes;
-    const TerminalColors* const colors = update->colors;
-    CellExtraStore* const extras = vt->extras.store;
     for (u16 row = 0; row < vt->geometry.rows; ++row) {
-        const ScreenRowRef view = screen->viewRow(row);
-        if (view.cells == nullptr) {
-            continue;
-        }
-        for (u16 column = 0; column < vt->geometry.columns; ++column) {
-            const TerminalCell& cell = view.cells[column];
-            if (cell.dwidth_cont) {
-                continue;
-            }
-            shitty_vt_cell out{};
-            u32 single = 0;
-            if (cell.hasExtra()) {
-                const GraphemeView grapheme = extras->grapheme(cell);
-                out.grapheme = grapheme.data();
-                out.grapheme_len = grapheme.count;
-            } else if (cell.uc_pt != 0) {
-                single = cell.uc_pt;
-                out.grapheme = &single;
-                out.grapheme_len = 1;
-            }
-            if (colors != nullptr) {
-                out.foreground = colors->resolveForeground(cell).packed();
-                out.background = colors->resolveBackground(cell).packed();
-                out.underline_color = colors->resolve(extras->underlineColor(cell)).packed();
-            }
-            out.attributes = (u16)(packAttributes(cell));
-            out.underline_style = (u8)(cell.underline_style);
-            out.width = cell.dwidth ? 2 : 1;
-            fn(user, row, column, &out);
-        }
+        emitRow(vt, update->colors, screen->viewRow(row), row, fn, user);
     }
     vt->terminal->consume();
 }
@@ -576,6 +582,33 @@ uint32_t shitty_vt_scroll_offset(const shitty_vt* vt) {
 uint32_t shitty_vt_history_rows(const shitty_vt* vt) {
     const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
     return update != nullptr ? update->historyRows : 0;
+}
+
+uint32_t shitty_vt_total_rows(const shitty_vt* vt) {
+    const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
+    return update != nullptr ? update->historyRows + vt->geometry.rows : 0;
+}
+
+void shitty_vt_row_cells(shitty_vt* vt, uint32_t index, shitty_vt_cell_fn fn, void* user) {
+    if (fn == nullptr) {
+        return;
+    }
+    const TerminalUpdate* update = currentUpdate(vt);
+    if (update == nullptr || update->shapes == nullptr) {
+        return;
+    }
+    if (index >= update->historyRows + vt->geometry.rows) {
+        return;
+    }
+    Screen* const screen = update->shapes;
+    // Logical row 0 is the top of the live screen and the history runs
+    // negative from there, so an oldest-first index sits historyRows
+    // above it. viewRow subtracts the current offset, so add it back and
+    // the read is independent of where the user has scrolled.
+    const i32 logical = (i32)(index) - (i32)(update->historyRows);
+    const i32 view = logical + (i32)(update->viewOffset);
+    emitRow(vt, update->colors, screen->viewRow(view), (u16)(index), fn, user);
+    vt->terminal->consume();
 }
 
 shitty_vt_cursor shitty_vt_cursor_state(const shitty_vt* vt) {

--- a/lib/embed/shitty_vt.h
+++ b/lib/embed/shitty_vt.h
@@ -132,6 +132,18 @@ extern "C" {
     /* Rows of scrollback retained, which is the largest offset
  * shitty_vt_scroll_to will accept. */
     uint32_t shitty_vt_history_rows(const shitty_vt*);
+
+    /* Rows addressable through shitty_vt_row_cells: the retained history
+ * followed by the visible grid. Index 0 is the oldest row still kept and
+ * the last index is the bottom of the live screen. */
+    uint32_t shitty_vt_total_rows(const shitty_vt*);
+
+    /* Walks one row by absolute index, oldest first, leaving the view
+ * where it is - the row argument handed to the callback is the index
+ * asked for. An index past the last row visits nothing. Use this to read
+ * the scrollback without scrolling; use shitty_vt_each_cell to read what
+ * the user is looking at. */
+    void shitty_vt_row_cells(shitty_vt*, uint32_t index, shitty_vt_cell_fn, void* user);
     shitty_vt_cursor shitty_vt_cursor_state(const shitty_vt*);
     uint32_t shitty_vt_modes(const shitty_vt*);
 

--- a/lib/embed/shitty_vt.h
+++ b/lib/embed/shitty_vt.h
@@ -65,6 +65,9 @@ extern "C" {
         uint8_t width;
     } shitty_vt_cell;
 
+    /* row is a row of the current view, not of the live screen: while the
+ * view sits in the scrollback the cursor can be at or past rows, which
+ * means it is simply not on screen and nothing should be drawn for it. */
     typedef struct shitty_vt_cursor {
         uint16_t column;
         uint16_t row;
@@ -107,8 +110,28 @@ extern "C" {
     size_t shitty_vt_take_replies(shitty_vt*, uint8_t* out, size_t cap);
 
     /* Walks the visible grid row-major; wide-cell continuations are
- * skipped. */
+ * skipped. Reads whatever the view currently shows, so it follows
+ * shitty_vt_scroll into the scrollback. */
     void shitty_vt_each_cell(shitty_vt*, shitty_vt_cell_fn, void* user);
+
+    /* Moves the view through the scrollback: positive rows scroll up into
+ * history, negative back toward the live bottom. Clamped to the retained
+ * history, and inert on the alternate screen, which keeps none. Returns
+ * the resulting offset. */
+    uint32_t shitty_vt_scroll(shitty_vt*, int32_t rows);
+
+    /* Places the view so that offset rows of history sit above it; 0 is
+ * the live bottom. Clamped like shitty_vt_scroll. Returns the resulting
+ * offset. */
+    uint32_t shitty_vt_scroll_to(shitty_vt*, uint32_t offset);
+
+    /* Rows of history above the live bottom the view currently shows;
+ * 0 while it is live. */
+    uint32_t shitty_vt_scroll_offset(const shitty_vt*);
+
+    /* Rows of scrollback retained, which is the largest offset
+ * shitty_vt_scroll_to will accept. */
+    uint32_t shitty_vt_history_rows(const shitty_vt*);
     shitty_vt_cursor shitty_vt_cursor_state(const shitty_vt*);
     uint32_t shitty_vt_modes(const shitty_vt*);
 

--- a/lib/embed/shitty_vt.h
+++ b/lib/embed/shitty_vt.h
@@ -138,6 +138,31 @@ extern "C" {
  * the last index is the bottom of the live screen. */
     uint32_t shitty_vt_total_rows(const shitty_vt*);
 
+    /* What the terminal is spending on its grid and history. Cells only:
+ * grapheme clusters, hyperlinks and sixel patches live in a separate
+ * store this does not count, so treat it as the floor of the real cost
+ * rather than the whole of it. */
+    typedef struct shitty_vt_memory {
+        /* Row slots actually backed by cells. The ring behind them is
+     * rounded up to a power of two, so this can exceed capacity_rows:
+     * it is what the screen costs, not what it is allowed to hold. */
+        uint32_t allocated_rows;
+        /* Rows the terminal will keep: rows + save_lines. */
+        uint32_t capacity_rows;
+        uint32_t columns;
+        /* Bytes in one cell, so an embedder can do its own arithmetic. */
+        uint32_t cell_size;
+        /* allocated_rows * columns * cell_size. */
+        uint64_t cell_bytes;
+    } shitty_vt_memory;
+
+    void shitty_vt_memory_usage(const shitty_vt*, shitty_vt_memory* out);
+
+    /* Changes how many rows of scrollback the terminal keeps. Lowering it
+ * drops the oldest rows that no longer fit, and does so at once rather
+ * than as the history is overwritten. The visible grid is untouched. */
+    void shitty_vt_set_save_lines(shitty_vt*, uint16_t save_lines);
+
     /* Walks one row by absolute index, oldest first, leaving the view
  * where it is - the row argument handed to the callback is the index
  * asked for. An index past the last row visits nothing. Use this to read

--- a/lib/vterm/screen.cpp
+++ b/lib/vterm/screen.cpp
@@ -384,6 +384,7 @@ namespace {
         using ScreenBase<Traits>::ScreenBase;
 
         Screen* resized(ObjPool& pool, u16 columns, u16 rows, Screen::Cursor& cursor, Screen::Cursor* trackedCursor) override;
+        Screen* resizedWithHistory(ObjPool& pool, u16 columns, u16 rows, u16 saveLines, Screen::Cursor& cursor, Screen::Cursor* trackedCursor) override;
         void dropHistory() override;
         void writeAsciiLines(u16 row, const u8* input, const u16* lengths, u16 lineCount, const TerminalCell& attrs, u32 hyperlink, u32 semantic, const TerminalCell& eraseAttrs) override;
         void scrollRows(u16 top, u16 bottom, i32 rows, const TerminalCell& attrs) override;
@@ -395,6 +396,7 @@ namespace {
         using ScreenBase<Traits>::ScreenBase;
 
         Screen* resized(ObjPool& pool, u16 columns, u16 rows, Screen::Cursor& cursor, Screen::Cursor* trackedCursor) override;
+        Screen* resizedWithHistory(ObjPool& pool, u16 columns, u16 rows, u16 saveLines, Screen::Cursor& cursor, Screen::Cursor* trackedCursor) override;
         void dropHistory() override;
         bool scrollView(i32 rows) override;
         void writeAsciiLines(u16 row, const u8* input, const u16* lengths, u16 lineCount, const TerminalCell& attrs, u32 hyperlink, u32 semantic, const TerminalCell& eraseAttrs) override;
@@ -816,8 +818,19 @@ Screen* Screen::createInactiveAlternate(VtCellExtras& extras, ObjPool& pool) {
 
 template <typename Traits>
 Screen* PrimaryScreenImpl<Traits>::resized(ObjPool& destination, u16 columns, u16 rows, Screen::Cursor& cursor, Screen::Cursor* trackedCursor) {
+    return this->resizedWithHistory(destination, columns, rows, (u16)(this->saveLines), cursor, trackedCursor);
+}
+
+template <typename Traits>
+Screen* PrimaryScreenImpl<Traits>::resizedWithHistory(ObjPool& destination, u16 columns, u16 rows, u16 saveLines, Screen::Cursor& cursor, Screen::Cursor* trackedCursor) {
     ResizeState* const resizeState = this->moveIntoState();
+    resizeState->saveLines = saveLines;
     return makePrimaryFromState(this->extras, destination, *resizeState, columns, rows, this->colors, cursor, trackedCursor);
+}
+
+template <typename Traits>
+Screen* AlternateScreenImpl<Traits>::resizedWithHistory(ObjPool& destination, u16 columns, u16 rows, u16, Screen::Cursor& cursor, Screen::Cursor* trackedCursor) {
+    return this->resized(destination, columns, rows, cursor, trackedCursor);
 }
 
 template <typename Traits>
@@ -843,6 +856,8 @@ ScreenInfo ScreenBase<Traits>::info() const noexcept {
         .viewOffset = viewOffset,
         .columns = nCols,
         .rows = nRows,
+        .saveLines = (u16)(saveLines),
+        .materializedRows = testMaterializedRows(),
     };
 }
 
@@ -1175,8 +1190,14 @@ template <typename Traits>
 template <bool primary>
 void ScreenBase<Traits>::layoutCopy(ResizeState& state, u16 nCols_, u16 nRows_, Cursor& cursorState, Cursor* trackedCursor) {
     Vector<const Row*> sourceHistory;
-    sourceHistory.grow(state.historyRows);
-    for (int row = -(int)(state.historyRows); row < 0; ++row) {
+    // A rebuild may be lowering the history cap, and the ring is sized
+    // for the new one: carrying every old row would claim more history
+    // than there are slots to hold it, and the surplus would wrap over
+    // rows still in use. Keep the newest that fit and drop the rest,
+    // which is what ageing them out would have done anyway.
+    const u32 carriedHistory = min<u32>(state.historyRows, (u32)(saveLines));
+    sourceHistory.grow(carriedHistory);
+    for (int row = -(int)(carriedHistory); row < 0; ++row) {
         sourceHistory.pushBack(stateRowObject(state, row));
     }
     Vector<const Row*> sourceScreen;

--- a/lib/vterm/screen.h
+++ b/lib/vterm/screen.h
@@ -56,6 +56,14 @@ struct ScreenInfo {
     u32 viewOffset = 0;
     u16 columns = 0;
     u16 rows = 0;
+    // Rows of history this screen is built to keep, which is what a
+    // caller compares against its own configuration to notice that the
+    // screen is stale. The alternate screen keeps none.
+    u16 saveLines = 0;
+    // Row slots actually backed by cells. The ring is rounded up to a
+    // power of two, so this can exceed rows + saveLines; it is what the
+    // screen costs rather than what it is allowed to hold.
+    u32 materializedRows = 0;
 };
 
 enum class ScreenSemanticPrompt : u8 {
@@ -91,6 +99,10 @@ struct Screen {
     };
 
     virtual Screen* resized(stl::ObjPool& pool, u16 columns, u16 rows, Cursor& cursor, Cursor* trackedCursor = nullptr) = 0;
+    // As resized, but also sets how many rows of history the result
+    // keeps: lowering it drops the oldest rows the new cap cannot hold.
+    // The alternate screen has no history and ignores the count.
+    virtual Screen* resizedWithHistory(stl::ObjPool& pool, u16 columns, u16 rows, u16 saveLines, Cursor& cursor, Cursor* trackedCursor = nullptr) = 0;
     virtual void dropHistory() = 0;
     virtual bool scrollView(i32 rows) = 0;
 

--- a/lib/vterm/vterm.cpp
+++ b/lib/vterm/vterm.cpp
@@ -2247,7 +2247,7 @@ void VtermImpl::resizeScreen(Screen*& frame, ObjPool*& pool, Screen::Cursor& cur
     ObjPool* const next = ObjPool::fromMemoryRaw();
     Screen* screen;
     try {
-        screen = frame->resized(*next, geometry.columns, geometry.rows, cursor, trackedStatePtr);
+        screen = frame->resizedWithHistory(*next, geometry.columns, geometry.rows, config().saveLines, cursor, trackedStatePtr);
     } catch (...) {
         delete next;
         throw;
@@ -3675,7 +3675,7 @@ void VtermImpl::switchScreenBufferMode(bool altScreenBufferMode_, bool clearAlte
         savedCursor = &savedCursorAlt;
         altScreenBufferMode = true;
     } else {
-        if (const ScreenInfo info = frame_pri->info(); info.columns != geometry.columns || info.rows != geometry.rows) {
+        if (const ScreenInfo info = frame_pri->info(); info.columns != geometry.columns || info.rows != geometry.rows || info.saveLines != config().saveLines) {
             Screen::Cursor cursorState{Point(posX, posY), lastCol};
             resizeScreen(frame_pri, framePriPool, cursorState, &savedCursorPri);
             posX = cursorState.position.x;
@@ -8842,6 +8842,8 @@ void VtermImpl::configChanged() {
     presentedTitle.xchg(nextPresentedTitle);
     titleSet = false;
     colors.changed();
+    updateExtraCellCount();
+    resizeGrid();
     exposeFrames();
     changePresentation();
     redraw();
@@ -8885,7 +8887,10 @@ void VtermImpl::resizeGrid() {
     const ScreenInfo info = cf->info();
     const u16 previousColumns = info.columns;
     const u16 previousRows = info.rows;
-    if (previousColumns == geometry.columns && previousRows == geometry.rows) {
+    // The history capacity is part of what makes a screen current: a
+    // configuration that only changed saveLines still needs the rebuild.
+    const bool historyCurrent = cf == frame_alt || info.saveLines == config().saveLines;
+    if (previousColumns == geometry.columns && previousRows == geometry.rows && historyCurrent) {
         if (synchronizedOutputMode) {
             setSynchronizedOutput(false);
         }

--- a/lib/vterm/vterm.cpp
+++ b/lib/vterm/vterm.cpp
@@ -444,6 +444,8 @@ namespace {
         void scrollDown(u16 count);
         void pageUp() override;
         void pageDown() override;
+        u32 scrollView(i32 rows) override;
+        u32 scrollViewTo(u32 offset) override;
         void selectionStart(int pixelX, int pixelY, bool cycleSnapTo);
         void selectionExtend(int pixelX, int pixelY, bool cycleSnapTo);
         void selectionUpdate(int pixelX, int pixelY);
@@ -3368,6 +3370,25 @@ void VtermImpl::pageUp() {
         refreshBlinkingText();
         redraw();
     }
+}
+
+u32 VtermImpl::scrollView(i32 rows) {
+    if (rows != 0) {
+        cf->scrollView(rows);
+        refreshBlinkingText();
+        redraw();
+    }
+    return cf->info().viewOffset;
+}
+
+u32 VtermImpl::scrollViewTo(u32 offset) {
+    const u32 current = cf->info().viewOffset;
+    if (offset == current) {
+        return current;
+    }
+    // scrollView moves by a delta and a positive delta scrolls up into
+    // history, so a larger target offset is a positive move.
+    return scrollView((i32)(offset) - (i32)(current));
 }
 
 void VtermImpl::pageDown() {

--- a/lib/vterm/vterm.h
+++ b/lib/vterm/vterm.h
@@ -185,6 +185,12 @@ struct Vterm {
     virtual void paste(bool primary) = 0;
     virtual void pageUp() = 0;
     virtual void pageDown() = 0;
+    // Moves the view through the scrollback: positive rows scroll up
+    // into history, negative back toward the live bottom. Both clamp to
+    // the retained history and return the resulting offset, which is 0
+    // once the view is live again.
+    virtual u32 scrollView(i32 rows) = 0;
+    virtual u32 scrollViewTo(u32 offset) = 0;
     // What Ctrl+L means, reached from a platform's own chord. The byte
     // goes to the shell rather than clearing here, so the shell's own
     // idea of a clear - prompt redraw and all - is what happens.

--- a/pty_test_helper
+++ b/pty_test_helper
@@ -1,0 +1,1 @@
+.build/pty_test_helper

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -35,6 +35,9 @@ class ExampleResult:
     history_rows: int
     total_rows: int
     rows_by_index: list[str]
+    allocated_rows: int
+    capacity_rows: int
+    cell_bytes: int
 
 
 def run_example(
@@ -45,6 +48,7 @@ def run_example(
     scroll=0,
     scroll_to=-1,
     dump_rows=0,
+    set_save_lines=-1,
 ):
     with tempfile.NamedTemporaryFile() as recorded:
         recorded.write(stream)
@@ -59,6 +63,7 @@ def run_example(
                 str(scroll),
                 str(scroll_to),
                 str(dump_rows),
+                str(set_save_lines),
             ],
             capture_output=True,
             timeout=60,
@@ -73,6 +78,7 @@ def run_example(
     rows_by_index = []
     while lines and lines[-1].startswith("row "):
         rows_by_index.insert(0, lines.pop())
+    memory_line = lines.pop()
     scrollback_line = lines.pop()
     replies_line = lines.pop()
     modes_line = lines.pop()
@@ -85,12 +91,17 @@ def run_example(
         raise RuntimeError(f"unexpected cursor line: {cursor_line!r}")
     if not scrollback_line.startswith("scrollback: "):
         raise RuntimeError(f"unexpected scrollback line: {scrollback_line!r}")
+    if not memory_line.startswith("memory: "):
+        raise RuntimeError(f"unexpected memory line: {memory_line!r}")
     grid = lines[len(lines) - rows :]
     events = lines[: len(lines) - rows]
     cursor_fields = cursor_line[len("cursor: ") :].split()
     replies = bytes.fromhex(replies_line[len("replies:") :].replace(" ", ""))
     scrollback_fields = scrollback_line[len("scrollback: ") :].split()
     indexed = [line.split(":", 1)[1] for line in rows_by_index]
+    memory_fields = dict(
+        field.split("=", 1) for field in memory_line[len("memory: ") :].split()
+    )
     return ExampleResult(
         events=events,
         lines=grid,
@@ -103,6 +114,9 @@ def run_example(
         history_rows=int(scrollback_fields[1].removeprefix("history=")),
         total_rows=int(scrollback_fields[2].removeprefix("total=")),
         rows_by_index=indexed,
+        allocated_rows=int(memory_fields["allocated_rows"]),
+        capacity_rows=int(memory_fields["capacity_rows"]),
+        cell_bytes=int(memory_fields["cell_bytes"]),
     )
 
 
@@ -477,4 +491,50 @@ class HistoryRowTest(unittest.TestCase):
         self.assertEqual(result.total_rows, 3 + ROWS)
         self.assertEqual(len(result.rows_by_index), 3 + ROWS)
         self.assertEqual(result.rows_by_index[0].rstrip(), "line32")
+
+
+class HistoryBudgetTest(unittest.TestCase):
+    """Changing the history cap after construction, and what it costs."""
+
+    @staticmethod
+    def stream(count):
+        return "".join(f"line{index}\r\n" for index in range(count)).encode()
+
+    def test_memory_grows_with_the_history_it_backs(self):
+        empty = run_example(b"", save_lines=100)
+        filled = run_example(self.stream(40), save_lines=100)
+        self.assertEqual(empty.cell_bytes, 0)
+        self.assertGreater(filled.allocated_rows, empty.allocated_rows)
+        self.assertEqual(
+            filled.cell_bytes,
+            filled.allocated_rows * COLUMNS * 16,
+            "cell_bytes should be rows * columns * cell_size",
+        )
+        # The cap is what it may hold, not what it holds.
+        self.assertEqual(filled.capacity_rows, ROWS + 100)
+
+    def test_lowering_the_cap_drops_the_oldest_rows_at_once(self):
+        result = run_example(self.stream(40), save_lines=100, set_save_lines=5)
+        self.assertEqual(result.history_rows, 5)
+        self.assertEqual(result.capacity_rows, ROWS + 5)
+        # Not merely reported: the surviving rows are the newest five.
+        rows = run_example(
+            self.stream(40), save_lines=100, set_save_lines=5, dump_rows=1
+        )
+        self.assertEqual(rows.rows_by_index[0].rstrip(), "line30")
+
+    def test_lowering_the_cap_releases_the_rows_it_dropped(self):
+        before = run_example(self.stream(40), save_lines=100)
+        after = run_example(self.stream(40), save_lines=100, set_save_lines=5)
+        self.assertLess(after.cell_bytes, before.cell_bytes)
+
+    def test_raising_the_cap_does_not_resurrect_dropped_rows(self):
+        result = run_example(self.stream(40), save_lines=5, set_save_lines=100)
+        self.assertEqual(result.capacity_rows, ROWS + 100)
+        self.assertEqual(result.history_rows, 5)
+
+    def test_the_visible_grid_survives_a_cap_change(self):
+        before = run_example(self.stream(40), save_lines=100)
+        after = run_example(self.stream(40), save_lines=100, set_save_lines=5)
+        self.assertEqual(after.lines, before.lines)
 

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -31,9 +31,11 @@ class ExampleResult:
     cursor_visible: bool
     modes: int
     replies: bytes
+    scroll_offset: int
+    history_rows: int
 
 
-def run_example(stream, columns=COLUMNS, rows=ROWS, save_lines=0):
+def run_example(stream, columns=COLUMNS, rows=ROWS, save_lines=0, scroll=0):
     with tempfile.NamedTemporaryFile() as recorded:
         recorded.write(stream)
         recorded.flush()
@@ -44,6 +46,7 @@ def run_example(stream, columns=COLUMNS, rows=ROWS, save_lines=0):
                 str(rows),
                 str(save_lines),
                 recorded.name,
+                str(scroll),
             ],
             capture_output=True,
             timeout=60,
@@ -55,6 +58,7 @@ def run_example(stream, columns=COLUMNS, rows=ROWS, save_lines=0):
     lines = result.stdout.decode("utf-8").split("\n")
     if lines and lines[-1] == "":
         lines.pop()
+    scrollback_line = lines.pop()
     replies_line = lines.pop()
     modes_line = lines.pop()
     cursor_line = lines.pop()
@@ -64,10 +68,13 @@ def run_example(stream, columns=COLUMNS, rows=ROWS, save_lines=0):
         raise RuntimeError(f"unexpected modes line: {modes_line!r}")
     if not cursor_line.startswith("cursor: "):
         raise RuntimeError(f"unexpected cursor line: {cursor_line!r}")
+    if not scrollback_line.startswith("scrollback: "):
+        raise RuntimeError(f"unexpected scrollback line: {scrollback_line!r}")
     grid = lines[len(lines) - rows :]
     events = lines[: len(lines) - rows]
     cursor_fields = cursor_line[len("cursor: ") :].split()
     replies = bytes.fromhex(replies_line[len("replies:") :].replace(" ", ""))
+    scrollback_fields = scrollback_line[len("scrollback: ") :].split()
     return ExampleResult(
         events=events,
         lines=grid,
@@ -76,6 +83,8 @@ def run_example(stream, columns=COLUMNS, rows=ROWS, save_lines=0):
         cursor_visible=bool(int(cursor_fields[3].removeprefix("visible="))),
         modes=int(modes_line[len("modes: ") :], 16),
         replies=replies,
+        scroll_offset=int(scrollback_fields[0].removeprefix("offset=")),
+        history_rows=int(scrollback_fields[1].removeprefix("history=")),
     )
 
 
@@ -341,3 +350,49 @@ class EmbedExampleTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ScrollbackTest(unittest.TestCase):
+    """The view movement the facade exposes, checked against the grid it
+    is supposed to move."""
+
+    @staticmethod
+    def stream(count):
+        return "".join(f"line{index}\r\n" for index in range(count)).encode()
+
+    def test_history_holds_what_scrolled_off_the_grid(self):
+        # Ten lines plus the trailing newline occupy eleven rows; six of
+        # them are on screen, so five went into the history.
+        kept = run_example(self.stream(10), save_lines=100)
+        self.assertEqual(kept.history_rows, 5)
+        self.assertEqual(kept.scroll_offset, 0)
+        self.assertEqual(kept.lines[0].rstrip(), "line5")
+
+    def test_a_terminal_keeping_no_lines_retains_no_history(self):
+        result = run_example(self.stream(10), save_lines=0)
+        self.assertEqual(result.history_rows, 0)
+
+    def test_history_is_capped_by_save_lines(self):
+        result = run_example(self.stream(40), save_lines=3)
+        self.assertEqual(result.history_rows, 3)
+
+    def test_scrolling_moves_the_view_over_the_history(self):
+        result = run_example(self.stream(10), save_lines=100, scroll=2)
+        self.assertEqual(result.scroll_offset, 2)
+        self.assertEqual(result.lines[0].rstrip(), "line3")
+
+    def test_scrolling_clamps_to_the_retained_history(self):
+        result = run_example(self.stream(10), save_lines=100, scroll=99)
+        self.assertEqual(result.scroll_offset, 5)
+        self.assertEqual(result.lines[0].rstrip(), "line0")
+
+    def test_scrolling_back_down_returns_to_the_live_bottom(self):
+        result = run_example(self.stream(10), save_lines=100, scroll=-5)
+        self.assertEqual(result.scroll_offset, 0)
+        self.assertEqual(result.lines[0].rstrip(), "line5")
+
+    def test_alternate_screen_has_no_history_to_scroll(self):
+        stream = b"\x1b[?1049h" + self.stream(10)
+        result = run_example(stream, save_lines=100, scroll=3)
+        self.assertEqual(result.history_rows, 0)
+        self.assertEqual(result.scroll_offset, 0)

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -33,10 +33,18 @@ class ExampleResult:
     replies: bytes
     scroll_offset: int
     history_rows: int
+    total_rows: int
+    rows_by_index: list[str]
 
 
 def run_example(
-    stream, columns=COLUMNS, rows=ROWS, save_lines=0, scroll=0, scroll_to=-1
+    stream,
+    columns=COLUMNS,
+    rows=ROWS,
+    save_lines=0,
+    scroll=0,
+    scroll_to=-1,
+    dump_rows=0,
 ):
     with tempfile.NamedTemporaryFile() as recorded:
         recorded.write(stream)
@@ -50,6 +58,7 @@ def run_example(
                 recorded.name,
                 str(scroll),
                 str(scroll_to),
+                str(dump_rows),
             ],
             capture_output=True,
             timeout=60,
@@ -61,6 +70,9 @@ def run_example(
     lines = result.stdout.decode("utf-8").split("\n")
     if lines and lines[-1] == "":
         lines.pop()
+    rows_by_index = []
+    while lines and lines[-1].startswith("row "):
+        rows_by_index.insert(0, lines.pop())
     scrollback_line = lines.pop()
     replies_line = lines.pop()
     modes_line = lines.pop()
@@ -78,6 +90,7 @@ def run_example(
     cursor_fields = cursor_line[len("cursor: ") :].split()
     replies = bytes.fromhex(replies_line[len("replies:") :].replace(" ", ""))
     scrollback_fields = scrollback_line[len("scrollback: ") :].split()
+    indexed = [line.split(":", 1)[1] for line in rows_by_index]
     return ExampleResult(
         events=events,
         lines=grid,
@@ -88,6 +101,8 @@ def run_example(
         replies=replies,
         scroll_offset=int(scrollback_fields[0].removeprefix("offset=")),
         history_rows=int(scrollback_fields[1].removeprefix("history=")),
+        total_rows=int(scrollback_fields[2].removeprefix("total=")),
+        rows_by_index=indexed,
     )
 
 
@@ -420,4 +435,46 @@ class ScrollbackTest(unittest.TestCase):
         result = run_example(self.stream(10), save_lines=100, scroll_to=99)
         self.assertEqual(result.scroll_offset, 5)
         self.assertEqual(result.lines[0].rstrip(), "line0")
+
+
+class HistoryRowTest(unittest.TestCase):
+    """Reading rows by index, which must not depend on where the view sits."""
+
+    @staticmethod
+    def stream(count):
+        return "".join(f"line{index}\r\n" for index in range(count)).encode()
+
+    def test_every_retained_row_is_addressable_oldest_first(self):
+        result = run_example(self.stream(10), save_lines=100, dump_rows=1)
+        # Five scrolled off, six on screen; the last is the blank row the
+        # trailing newline opened.
+        self.assertEqual(result.total_rows, 11)
+        self.assertEqual(len(result.rows_by_index), 11)
+        self.assertEqual(
+            [row.rstrip() for row in result.rows_by_index[:6]],
+            ["line0", "line1", "line2", "line3", "line4", "line5"],
+        )
+        self.assertEqual(result.rows_by_index[10].strip(), "")
+
+    def test_row_reads_ignore_the_view_position(self):
+        live = run_example(self.stream(10), save_lines=100, dump_rows=1)
+        scrolled = run_example(
+            self.stream(10), save_lines=100, scroll=3, dump_rows=1
+        )
+        self.assertEqual(scrolled.scroll_offset, 3)
+        self.assertEqual(scrolled.rows_by_index, live.rows_by_index)
+
+    def test_a_terminal_without_history_addresses_only_the_grid(self):
+        result = run_example(self.stream(10), save_lines=0, dump_rows=1)
+        self.assertEqual(result.total_rows, ROWS)
+        self.assertEqual(result.rows_by_index[0].rstrip(), "line5")
+
+    def test_reading_past_the_last_row_yields_nothing(self):
+        # The example only walks in range, so drive the edge through a
+        # terminal whose history is capped: index total-1 is the last row
+        # and the dump stops there rather than running on.
+        result = run_example(self.stream(40), save_lines=3, dump_rows=1)
+        self.assertEqual(result.total_rows, 3 + ROWS)
+        self.assertEqual(len(result.rows_by_index), 3 + ROWS)
+        self.assertEqual(result.rows_by_index[0].rstrip(), "line32")
 

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -35,7 +35,9 @@ class ExampleResult:
     history_rows: int
 
 
-def run_example(stream, columns=COLUMNS, rows=ROWS, save_lines=0, scroll=0):
+def run_example(
+    stream, columns=COLUMNS, rows=ROWS, save_lines=0, scroll=0, scroll_to=-1
+):
     with tempfile.NamedTemporaryFile() as recorded:
         recorded.write(stream)
         recorded.flush()
@@ -47,6 +49,7 @@ def run_example(stream, columns=COLUMNS, rows=ROWS, save_lines=0, scroll=0):
                 str(save_lines),
                 recorded.name,
                 str(scroll),
+                str(scroll_to),
             ],
             capture_output=True,
             timeout=60,
@@ -396,3 +399,25 @@ class ScrollbackTest(unittest.TestCase):
         result = run_example(stream, save_lines=100, scroll=3)
         self.assertEqual(result.history_rows, 0)
         self.assertEqual(result.scroll_offset, 0)
+
+    def test_scrolling_to_an_absolute_offset_lands_there(self):
+        result = run_example(self.stream(10), save_lines=100, scroll_to=3)
+        self.assertEqual(result.scroll_offset, 3)
+        self.assertEqual(result.lines[0].rstrip(), "line2")
+
+    def test_scrolling_to_the_current_offset_changes_nothing(self):
+        # The no-op path: settle at 2 relatively, then ask for 2 again.
+        result = run_example(self.stream(10), save_lines=100, scroll=2, scroll_to=2)
+        self.assertEqual(result.scroll_offset, 2)
+        self.assertEqual(result.lines[0].rstrip(), "line3")
+
+    def test_scrolling_to_zero_returns_to_the_live_bottom(self):
+        result = run_example(self.stream(10), save_lines=100, scroll=4, scroll_to=0)
+        self.assertEqual(result.scroll_offset, 0)
+        self.assertEqual(result.lines[0].rstrip(), "line5")
+
+    def test_scrolling_to_past_the_history_clamps(self):
+        result = run_example(self.stream(10), save_lines=100, scroll_to=99)
+        self.assertEqual(result.scroll_offset, 5)
+        self.assertEqual(result.lines[0].rstrip(), "line0")
+


### PR DESCRIPTION
> **Stacked on #99.** Until that merges this shows both commits; the one to
> review here is `Read scrollback rows by index through the facade`.

## Problem

#99 lets an embedder move the view, which is enough to *show* a user their
history. It is not enough to search it, export it, or hand the buffer to
something that wants all of it — each of those wants a row without disturbing
what the user is looking at, and scrolling to read would do exactly that.

## Change

```c
uint32_t shitty_vt_total_rows(const shitty_vt*);
void shitty_vt_row_cells(shitty_vt*, uint32_t index, shitty_vt_cell_fn, void* user);
```

Index 0 is the oldest retained row, the last index is the bottom of the live
screen, and the callback receives the index it was asked for. A caller walks the
whole buffer without needing to know where the history ends and the grid begins.

**No core change.** `Screen` already addresses rows this way: logical row 0 is
the top of the live screen with the history running negative, and `viewRow`
subtracts the current offset. So the implementation converts an oldest-first
index to a logical row and adds the offset back, which is what makes the read
independent of where the user has scrolled.

The per-row cell walk `shitty_vt_each_cell` was doing is factored into a shared
helper rather than duplicated; `each_cell` is now a loop over it.

## Tests

`bin/example` grows a flag that prints every addressable row after the grid, and
`run_example` parses them.

Four cases: every retained row is addressable oldest-first, row reads ignore the
view position (same output scrolled and live), a terminal without history
addresses only the grid, and a capped history addresses exactly `save_lines`
rows before the grid.

`test_embed_example` — 52 passed (48 after #99, 37 before it).

First quarter of the python suite: 1600 tests, one failure —
`test_emoji_renders_in_color_out_of_the_box`, which fails identically with the
change stashed and is this machine's fonts.

## Also here

A second commit adds byte accounting (`shitty_vt_memory_usage`) and a changeable
history cap (`shitty_vt_set_save_lines`), which together close the scrollback
story: an embedder can now read history, budget it, and shrink it. See the
comment below for the detail, including a latent rebuild bug the cap change
surfaced and a config-reload gap it fixes along the way.

