### PR TITLE
Report alternate scroll through the facade

### DIFF
--- a/example
+++ b/example
@@ -1,0 +1,1 @@
+.build/example

--- a/lib/embed/shitty_vt.cpp
+++ b/lib/embed/shitty_vt.cpp
@@ -591,5 +591,6 @@ uint32_t shitty_vt_modes(const shitty_vt* vt) {
     modes |= state.mouseTracking == MouseTrackingMode::VT200_ButtonEvent ? SHITTY_VT_MODE_MOUSE_DRAG : 0;
     modes |= state.mouseTracking == MouseTrackingMode::VT200_AnyEvent ? SHITTY_VT_MODE_MOUSE_MOTION : 0;
     modes |= state.mouseEncoding == MouseTrackingEnc::SGR || state.mouseEncoding == MouseTrackingEnc::SGRPixels ? SHITTY_VT_MODE_MOUSE_SGR : 0;
+    modes |= state.alternateScroll ? SHITTY_VT_MODE_ALTERNATE_SCROLL : 0;
     return modes;
 }

--- a/lib/embed/shitty_vt.h
+++ b/lib/embed/shitty_vt.h
@@ -46,6 +46,9 @@ extern "C" {
 #define SHITTY_VT_MODE_MOUSE_DRAG (1u << 12)
 #define SHITTY_VT_MODE_MOUSE_MOTION (1u << 13)
 #define SHITTY_VT_MODE_MOUSE_SGR (1u << 14)
+/* DECSET 1007: while the alternate screen is up, wheel input should be
+ * sent as arrow keys rather than scrolling a history it does not keep. */
+#define SHITTY_VT_MODE_ALTERNATE_SCROLL (1u << 15)
 
     /* One readable cell. Colors are resolved through the palette into
  * 0x00BBGGRR - the little-endian view of struct { uint8_t r, g, b; }.

--- a/lib/shitty/test_mode.cpp
+++ b/lib/shitty/test_mode.cpp
@@ -1138,6 +1138,7 @@ namespace {
         u8 getLedState();
         bool getReverseWrapMode();
         bool getNationalReplacementMode();
+        bool getAlternateScroll();
         bool getAnsiMode(u32 mode);
         bool getPrivateMode(u32 mode);
         bool getTabStop(u16 column);
@@ -1708,6 +1709,13 @@ MouseTrackingState TestTerminal::getMouseTrackingState() {
 
 u8 TestTerminal::getKittyKeyboardFlags() {
     return testApi.inspect().kittyKeyboardFlags;
+}
+
+bool TestTerminal::getAlternateScroll() {
+    // Read through the terminal's own state accessor rather than the
+    // test api, so this exercises what a client outside the terminal
+    // actually sees.
+    return terminal.state().alternateScroll;
 }
 
 bool TestTerminal::getScreenReverseVideo() {
@@ -3149,7 +3157,7 @@ int runTestMode(Composer& composer, TestInput& input, plt::WindowEvents& events,
                         const auto& mouse = terminal.getMouseTrackingState();
                         writeParts(controlFd, StringView(u8"OK "), (i64)((unsigned)(mouse.mode)), StringView(u8" "), (i64)((unsigned)(mouse.enc)), StringView(u8" "), (i64)(mouse.focusEventMode), StringView(u8" "), (i64)(terminal.getKittyKeyboardFlags()), StringView(u8"\n"));
                     } else if (line == StringView(u8"PROTOCOL_STATE")) {
-                        writeParts(controlFd, StringView(u8"OK "), (i64)(terminal.getScreenReverseVideo()), StringView(u8" "), (i64)(terminal.getLedState()), StringView(u8" "), (i64)(terminal.getReverseWrapMode()), StringView(u8" "), (i64)(terminal.getNationalReplacementMode()), StringView(u8" 0\n"));
+                        writeParts(controlFd, StringView(u8"OK "), (i64)(terminal.getScreenReverseVideo()), StringView(u8" "), (i64)(terminal.getLedState()), StringView(u8" "), (i64)(terminal.getReverseWrapMode()), StringView(u8" "), (i64)(terminal.getNationalReplacementMode()), StringView(u8" "), (i64)(terminal.getAlternateScroll()), StringView(u8"\n"));
                     } else if (line == StringView(u8"CURSOR_STATE")) {
                         writeParts(controlFd, StringView(u8"OK "), (i64)(terminal.getPrivateMode(25)), StringView(u8" "), (i64)(terminal.getPrivateMode(12)), StringView(u8" "), (i64)((unsigned)(terminal.getCursorStyle())), StringView(u8"\n"));
                     } else if (line == StringView(u8"CURSOR_PENDING_WRAP")) {

--- a/lib/vterm/vterm.cpp
+++ b/lib/vterm/vterm.cpp
@@ -2771,6 +2771,7 @@ VtermState VtermImpl::state() const {
     result.insertMode = insertMode;
     result.showCursor = showCursorMode;
     result.screenReverse = screenReverseVideo;
+    result.alternateScroll = altScrollMode;
     return result;
 }
 

--- a/lib/vterm/vterm.h
+++ b/lib/vterm/vterm.h
@@ -123,6 +123,9 @@ struct VtermState {
     bool insertMode = false;
     bool showCursor = false;
     bool screenReverse = false;
+    // DECSET 1007: on the alternate screen the wheel sends arrow keys
+    // rather than moving a history the alternate screen does not have.
+    bool alternateScroll = false;
 };
 
 struct TerminalUpdate {

--- a/pty_test_helper
+++ b/pty_test_helper
@@ -1,0 +1,1 @@
+.build/pty_test_helper

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -92,6 +92,7 @@ MODE_SCREEN_REVERSE = 1 << 9
 MODE_MOUSE_CLICK = 1 << 11
 MODE_MOUSE_MOTION = 1 << 13
 MODE_MOUSE_SGR = 1 << 14
+MODE_ALTERNATE_SCROLL = 1 << 15
 
 
 class EmbedExampleTest(unittest.TestCase):
@@ -159,6 +160,25 @@ class EmbedExampleTest(unittest.TestCase):
         self.assertTrue(result.modes & MODE_MOUSE_MOTION)
         self.assertTrue(result.modes & MODE_MOUSE_SGR)
         self.assertFalse(result.modes & MODE_CURSOR_VISIBLE)
+
+    def test_alternate_scroll_is_reported_and_cleared(self):
+        # DECSET 1007 stands on its own: a host reads it to decide whether
+        # wheel input becomes arrow keys, which only matters once the
+        # alternate screen is up, but the mode is settable either side of
+        # that and must not be conflated with it.
+        self.assertFalse(run_example(b"").modes & MODE_ALTERNATE_SCROLL)
+
+        armed = run_example(b"\x1b[?1007h")
+        self.assertTrue(armed.modes & MODE_ALTERNATE_SCROLL)
+        self.assertFalse(armed.modes & MODE_ALT_SCREEN)
+
+        both = run_example(b"\x1b[?1007h\x1b[?1049h")
+        self.assertTrue(both.modes & MODE_ALTERNATE_SCROLL)
+        self.assertTrue(both.modes & MODE_ALT_SCREEN)
+
+        cleared = run_example(b"\x1b[?1007h\x1b[?1049h\x1b[?1007l")
+        self.assertFalse(cleared.modes & MODE_ALTERNATE_SCROLL)
+        self.assertTrue(cleared.modes & MODE_ALT_SCREEN)
 
     def test_keypad_origin_and_reverse_modes(self):
         result = run_example(b"\x1b=\x1b[?6h\x1b[?5h\x1b[4h")

--- a/tst/test_terminal_modes.py
+++ b/tst/test_terminal_modes.py
@@ -244,3 +244,17 @@ class TerminalModeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+    def test_alternate_scroll_mode_is_reported(self):
+        # DECSET 1007 read back through the terminal's own state, which is
+        # the accessor a client outside the terminal uses; it is
+        # independent of the alternate screen it applies on.
+        with Shitty() as terminal:
+            self.assertEqual(terminal.protocol_state()[4], 0)
+            terminal.write(b"\x1b[?1007h")
+            self.assertEqual(terminal.protocol_state()[4], 1)
+            terminal.write(b"\x1b[?1049h")
+            self.assertEqual(terminal.protocol_state()[4], 1)
+            terminal.write(b"\x1b[?1007l")
+            self.assertEqual(terminal.protocol_state()[4], 0)
+


### PR DESCRIPTION
Independent of #99 and #100 — based on `master`, touching a different part of the
header, so it can merge in any order.

## Problem

`shitty_vt_modes` reports fourteen modes but not DECSET 1007. That one decides
what a host does with a wheel event: on the alternate screen it should reach the
application as arrow keys rather than move a history the alternate screen does
not keep. Without it an embedder has to guess, and guessing wrong is the
difference between `less` scrolling and `less` ignoring the wheel.

The terminal has tracked the mode all along — DECRQM answers for it and
`setAlternateScroll` sets it — but `VtermState` never carried it, so nothing
outside the terminal could ask.

## Change

Carry `alternateScroll` on `VtermState`, report it as
`SHITTY_VT_MODE_ALTERNATE_SCROLL` (bit 15).

## Behaviour

Checked from a C consumer linking only the static library:

```text
fresh                        alt_screen=0 alternate_scroll=0
after DECSET 1007            alt_screen=0 alternate_scroll=1
on the alternate screen      alt_screen=1 alternate_scroll=1
after DECRST 1007            alt_screen=1 alternate_scroll=0
```

The mode is settable either side of the alternate-screen switch and is not
conflated with it, which is the part worth pinning: a host reads both and acts
on the pair.

## Tests

`test_alternate_scroll_is_reported_and_cleared` covers all four states above.

- `test_embed_example` — 38 passed
- first shard of the python suite — 1597 tests, one failure
  (`test_zwj_cluster_renders_through_one_fallback_face`), which fails identically
  with the change stashed and is this machine's fonts
- `unit_tests` — 632 passed

## Note

`./build so` fails on this branch, but for an unrelated reason that #97 fixes:
the shared link does not forward libstd's probed backends, so it cannot resolve
`XXH3_64bits` on a host that has `xxhash.h` and no `rapidhash.h`. `./build a` and
the example are unaffected, and that is what the verification above used.
