### PR TITLE
Reach the composition preview from the embedding facade

### DIFF
--- a/bin/example/main.c
+++ b/bin/example/main.c
@@ -23,7 +23,8 @@
  *   wheel DX DY COL ROW MODS
  *   paste HEXBYTES
  *   feed HEXBYTES
- *   focus 0|1 */
+ *   focus 0|1
+ *   preedit HEXBYTES BEGIN END */
 
 #include "lib/embed/shitty_vt.h"
 
@@ -82,6 +83,28 @@ static void collect_cell(void* user, uint16_t row, uint16_t column, const shitty
     slot[used] = '\0';
 }
 
+/* The preview cells with the span they cover: the callback reports the
+ * columns they are drawn at, which is not where the row starts. */
+struct preview_span {
+    struct grid* grid;
+    uint16_t row;
+    uint16_t column;
+    uint16_t count;
+};
+
+static void collect_preview(void* user, uint16_t row, uint16_t column, const shitty_vt_cell* cell) {
+    struct preview_span* const span = user;
+    if (column >= span->grid->columns) {
+        return;
+    }
+    span->row = row;
+    if (column < span->column) {
+        span->column = column;
+    }
+    ++span->count;
+    collect_cell(span->grid, 0, column, cell);
+}
+
 static void on_title(void* user, const uint8_t* title, size_t len) {
     (void)user;
     printf("title: %.*s\n", (int)len, (const char*)title);
@@ -127,6 +150,8 @@ static void run_input_line(shitty_vt* vt, const char* line) {
     unsigned f = 0;
     double x = 0;
     double y = 0;
+    int begin = 0;
+    int end = 0;
     char payload[4096];
     uint8_t bytes[2048];
     if (sscanf(line, "key %u %u %u %u %u %u", &a, &b, &c, &d, &e, &f) == 6) {
@@ -154,6 +179,10 @@ static void run_input_line(shitty_vt* vt, const char* line) {
         shitty_vt_feed(vt, bytes, parse_hex(payload, bytes, sizeof(bytes)));
     } else if (sscanf(line, "focus %u", &a) == 1) {
         shitty_vt_focus(vt, (int)a);
+    } else if (sscanf(line, "preedit %4095s %d %d", payload, &begin, &end) == 3) {
+        /* "-" is the empty preview that clears a composition. */
+        const size_t used = strcmp(payload, "-") == 0 ? 0 : parse_hex(payload, bytes, sizeof(bytes));
+        shitty_vt_preedit(vt, bytes, used, begin, end);
     }
 }
 
@@ -298,6 +327,37 @@ int main(int argc, char** argv) {
         shitty_vt_memory memory;
         shitty_vt_memory_usage(vt, &memory);
         printf("memory: allocated_rows=%u capacity_rows=%u columns=%u cell_size=%u cell_bytes=%llu\n", memory.allocated_rows, memory.capacity_rows, memory.columns, memory.cell_size, (unsigned long long)memory.cell_bytes);
+    }
+
+    {
+        struct grid preview;
+        uint16_t column;
+        preview.columns = columns;
+        preview.rows = 1;
+        preview.text = calloc(columns, CELL_TEXT_CAP);
+        if (preview.text == NULL) {
+            shitty_vt_free(vt);
+            return 1;
+        }
+        for (column = 0; column < columns; ++column) {
+            preview.text[column * CELL_TEXT_CAP] = '\0';
+        }
+        struct preview_span span;
+        span.grid = &preview;
+        span.row = 0;
+        span.column = columns;
+        span.count = 0;
+        shitty_vt_preedit_cells(vt, collect_preview, &span);
+        if (span.count == 0) {
+            fputs("preedit: none\n", stdout);
+        } else {
+            printf("preedit: row=%u column=%u cells=%u text=", span.row, span.column, span.count);
+            for (column = span.column; column < columns; ++column) {
+                fputs(preview.text + column * CELL_TEXT_CAP, stdout);
+            }
+            fputc('\n', stdout);
+        }
+        free(preview.text);
     }
 
     if (dump_rows) {

--- a/lib/embed/shitty_vt.cpp
+++ b/lib/embed/shitty_vt.cpp
@@ -459,39 +459,44 @@ namespace {
         return attributes;
     }
 
-    // One row of cells handed to an embedder's callback. The row number
-    // is passed through rather than derived, so a caller reading the
-    // history by index reports that index.
+    // One cell handed to an embedder's callback. The position is passed
+    // through rather than derived, so a caller reading the history by
+    // index reports that index, and the preview reports where it is
+    // drawn. The continuation of a wide cell is not reported.
+    static void emitCell(shitty_vt* vt, const TerminalColors* colors, const TerminalCell& cell, u16 row, u16 column, shitty_vt_cell_fn fn, void* user) {
+        if (cell.dwidth_cont) {
+            return;
+        }
+        CellExtraStore* const extras = vt->extras.store;
+        shitty_vt_cell out{};
+        u32 single = 0;
+        if (cell.hasExtra()) {
+            const GraphemeView grapheme = extras->grapheme(cell);
+            out.grapheme = grapheme.data();
+            out.grapheme_len = grapheme.count;
+        } else if (cell.uc_pt != 0) {
+            single = cell.uc_pt;
+            out.grapheme = &single;
+            out.grapheme_len = 1;
+        }
+        if (colors != nullptr) {
+            out.foreground = colors->resolveForeground(cell).packed();
+            out.background = colors->resolveBackground(cell).packed();
+            out.underline_color = colors->resolve(extras->underlineColor(cell)).packed();
+        }
+        out.attributes = (u16)(packAttributes(cell));
+        out.underline_style = (u8)(cell.underline_style);
+        out.width = cell.dwidth ? 2 : 1;
+        fn(user, row, column, &out);
+    }
+
+    // One row of cells, in the row's own columns.
     static void emitRow(shitty_vt* vt, const TerminalColors* colors, const ScreenRowRef& source, u16 row, shitty_vt_cell_fn fn, void* user) {
         if (source.cells == nullptr) {
             return;
         }
-        CellExtraStore* const extras = vt->extras.store;
         for (u16 column = 0; column < vt->geometry.columns; ++column) {
-            const TerminalCell& cell = source.cells[column];
-            if (cell.dwidth_cont) {
-                continue;
-            }
-            shitty_vt_cell out{};
-            u32 single = 0;
-            if (cell.hasExtra()) {
-                const GraphemeView grapheme = extras->grapheme(cell);
-                out.grapheme = grapheme.data();
-                out.grapheme_len = grapheme.count;
-            } else if (cell.uc_pt != 0) {
-                single = cell.uc_pt;
-                out.grapheme = &single;
-                out.grapheme_len = 1;
-            }
-            if (colors != nullptr) {
-                out.foreground = colors->resolveForeground(cell).packed();
-                out.background = colors->resolveBackground(cell).packed();
-                out.underline_color = colors->resolve(extras->underlineColor(cell)).packed();
-            }
-            out.attributes = (u16)(packAttributes(cell));
-            out.underline_style = (u8)(cell.underline_style);
-            out.width = cell.dwidth ? 2 : 1;
-            fn(user, row, column, &out);
+            emitCell(vt, colors, source.cells[column], row, column, fn, user);
         }
     }
 
@@ -771,6 +776,26 @@ void shitty_vt_paste(shitty_vt* vt, const uint8_t* bytes, size_t len) {
 
 void shitty_vt_focus(shitty_vt* vt, int focused) {
     vt->terminal->focus(focused != 0);
+}
+
+void shitty_vt_preedit(shitty_vt* vt, const uint8_t* text, size_t len, int32_t cursor_begin, int32_t cursor_end) {
+    if (text == nullptr && len != 0) {
+        return;
+    }
+    vt->terminal->preedit(StringView((const u8*)(text), len), cursor_begin, cursor_end);
+}
+
+void shitty_vt_preedit_cells(shitty_vt* vt, shitty_vt_cell_fn fn, void* user) {
+    if (fn == nullptr) {
+        return;
+    }
+    const TerminalUpdate* update = currentUpdate(vt);
+    if (update == nullptr || update->overlayCells == nullptr) {
+        return;
+    }
+    for (u16 index = 0; index < update->overlayCount; ++index) {
+        emitCell(vt, update->colors, update->overlayCells[index], update->overlayRow, (u16)(update->overlayColumn + index), fn, user);
+    }
 }
 
 shitty_vt_cursor shitty_vt_cursor_state(const shitty_vt* vt) {

--- a/lib/embed/shitty_vt.h
+++ b/lib/embed/shitty_vt.h
@@ -394,6 +394,28 @@ extern "C" {
     /* Keyboard focus, reported to applications that asked for focus
      * events. A fresh terminal is focused. */
     void shitty_vt_focus(shitty_vt*, int focused);
+
+    /* The text an input method is composing, before it commits. The
+     * preview is drawn over the cursor row and belongs to no one else:
+     * it never enters the grid, the scrollback or the replies, and the
+     * committed text arrives later as ordinary shitty_vt_text events.
+     * Empty text clears it.
+     *
+     * cursor_begin and cursor_end are byte offsets into text, or -1 when
+     * the input method hides its cursor. That range is shown in reverse
+     * video, the rest of the preview underlined.
+     *
+     * While a preview is up shitty_vt_cursor_state reports a hidden
+     * cursor positioned at the preview's cursor cell, which is where an
+     * input method wants its candidate window. */
+    void shitty_vt_preedit(shitty_vt*, const uint8_t* text, size_t len, int32_t cursor_begin, int32_t cursor_end);
+
+    /* Visits the preview's cells left to right, at the row and columns
+     * they cover; visits nothing when no preview is active. They are an
+     * overlay, so shitty_vt_each_cell does not report them and what
+     * they cover is still underneath - draw them last. A preview too
+     * wide for the row is clipped to it, keeping the freshest input. */
+    void shitty_vt_preedit_cells(shitty_vt*, shitty_vt_cell_fn, void* user);
 #ifdef __cplusplus
 }
 #endif

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -38,6 +38,17 @@ class ExampleResult:
     allocated_rows: int
     capacity_rows: int
     cell_bytes: int
+    preedit: "Preedit | None"
+
+
+@dataclass
+class Preedit:
+    """The composition preview: where it is drawn and what it shows."""
+
+    row: int
+    column: int
+    cells: int
+    text: str
 
 
 def run_example(
@@ -85,6 +96,7 @@ def run_example(
     rows_by_index = []
     while lines and lines[-1].startswith("row "):
         rows_by_index.insert(0, lines.pop())
+    preedit_line = lines.pop()
     memory_line = lines.pop()
     scrollback_line = lines.pop()
     replies_line = lines.pop()
@@ -100,6 +112,8 @@ def run_example(
         raise RuntimeError(f"unexpected scrollback line: {scrollback_line!r}")
     if not memory_line.startswith("memory: "):
         raise RuntimeError(f"unexpected memory line: {memory_line!r}")
+    if not preedit_line.startswith("preedit: "):
+        raise RuntimeError(f"unexpected preedit line: {preedit_line!r}")
     grid = lines[len(lines) - rows :]
     events = lines[: len(lines) - rows]
     cursor_fields = cursor_line[len("cursor: ") :].split()
@@ -109,6 +123,16 @@ def run_example(
     memory_fields = dict(
         field.split("=", 1) for field in memory_line[len("memory: ") :].split()
     )
+    preedit = None
+    if preedit_line != "preedit: none":
+        head, text = preedit_line[len("preedit: ") :].split("text=", 1)
+        preedit_fields = dict(field.split("=", 1) for field in head.split())
+        preedit = Preedit(
+            row=int(preedit_fields["row"]),
+            column=int(preedit_fields["column"]),
+            cells=int(preedit_fields["cells"]),
+            text=text,
+        )
     return ExampleResult(
         events=events,
         lines=grid,
@@ -124,6 +148,7 @@ def run_example(
         allocated_rows=int(memory_fields["allocated_rows"]),
         capacity_rows=int(memory_fields["capacity_rows"]),
         cell_bytes=int(memory_fields["cell_bytes"]),
+        preedit=preedit,
     )
 
 
@@ -689,3 +714,65 @@ class InputEncodingTest(unittest.TestCase):
         self.assertIn("clipboard 0: grab", result.events)
         self.assertEqual(result.replies, b"")
 
+
+
+def preedit_command(text, begin=-1, end=-1):
+    payload = text.encode().hex() if text else "-"
+    return f"preedit {payload} {begin} {end}"
+
+
+class PreeditTest(unittest.TestCase):
+    """The composition preview: an input method's uncommitted text, drawn
+    over the cursor row and belonging to no one else - not the grid, not
+    the scrollback, not the child."""
+
+    def test_the_preview_is_drawn_from_the_cursor(self):
+        result = run_example(b"hello", input_script=[preedit_command("abc", 0, 3)])
+        self.assertEqual(
+            result.preedit, Preedit(row=0, column=5, cells=3, text="abc")
+        )
+
+    def test_the_preview_stays_out_of_the_grid_and_the_child(self):
+        result = run_example(b"hello", input_script=[preedit_command("abc", 0, 3)])
+        # The row still holds what the application wrote, and the child
+        # hears nothing until the input method commits.
+        self.assertEqual(result.lines[0].rstrip(), "hello")
+        self.assertEqual(result.replies, b"")
+
+    def test_the_cursor_hides_and_anchors_the_candidate_window(self):
+        # The input method draws its candidate list at the cursor, so
+        # while composing the cursor tracks the preview's own cursor
+        # rather than the application's.
+        result = run_example(b"hello", input_script=[preedit_command("abc", 1, 1)])
+        self.assertEqual(result.cursor, (6, 0))
+        self.assertFalse(result.cursor_visible)
+
+    def test_an_empty_preview_clears_the_composition(self):
+        result = run_example(
+            b"hello",
+            input_script=[preedit_command("abc", 0, 3), preedit_command("")],
+        )
+        self.assertIsNone(result.preedit)
+        # And the application's cursor comes back where it was.
+        self.assertEqual(result.cursor, (5, 0))
+        self.assertTrue(result.cursor_visible)
+
+    def test_a_wide_character_takes_two_columns_of_the_preview(self):
+        # Continuations are not reported, as everywhere else: two cells
+        # covering four columns.
+        result = run_example(
+            b"hello", input_script=[preedit_command("日本", 0, 6)]
+        )
+        self.assertEqual(
+            result.preedit,
+            Preedit(row=0, column=5, cells=2, text="日本"),
+        )
+
+    def test_a_preview_too_long_for_the_row_keeps_the_fresh_end(self):
+        result = run_example(
+            b"", input_script=[preedit_command("abcdefghijklmnopqrstuvwxyz", 0, 26)]
+        )
+        self.assertEqual(
+            result.preedit,
+            Preedit(row=0, column=0, cells=COLUMNS, text="ghijklmnopqrstuvwxyz"),
+        )


### PR DESCRIPTION
`Vterm::preedit` is driven by every frontend and by the test harness, and it was the one input path #103 left behind the facade. An embedder with an input method can send the committed text but cannot show what is being composed — a CJK or dead-key user types blind — and the terminal's cursor goes on claiming a position that, while composing, belongs to the input method's candidate window.

Two entry points:

```c
void shitty_vt_preedit(shitty_vt*, const uint8_t* text, size_t len,
                       int32_t cursor_begin, int32_t cursor_end);
void shitty_vt_preedit_cells(shitty_vt*, shitty_vt_cell_fn, void* user);
```

The reader is needed because the preview is an overlay: it exists outside the screen model, so `shitty_vt_each_cell` does not report it and an embedder drawing its own cells would have nothing to draw. It reports the cells at the row and columns they cover, so they can be drawn last over the grid underneath.

Nothing here re-decides what the core already decides. The preview's underline, the reverse-video cursor range, the foot-style clip that keeps the freshest input when a preview is wider than the row, the hidden terminal cursor and its move to the preview's cursor cell — all of it comes from `overlayPreedit` and is only carried across the boundary.

The per-cell conversion moves out of `emitRow`, which walked a screen row, so the overlay's loose cell run can share it. The walk itself is unchanged.

The example grows a `preedit HEXBYTES BEGIN END` command and prints the preview it can read, which the six new tests drive:

- the preview is drawn from the cursor
- it stays out of the grid and out of the child (the row keeps what the application wrote; replies stay empty)
- the cursor hides and anchors the candidate window at the preview's cursor cell
- an empty preview clears the composition and gives the application's cursor back
- a wide character takes two columns and is reported as one cell
- a preview too long for the row keeps its fresh end

`tst/test_embed_example.py` is 77 tests green with these.

---

While reading the input path for this I answered my own question on #103, and the answer is that there is nothing to fix there: deriving the associated text from the key event's codepoints is right for this model, and `test_kitty_associated_text_sequence_tracks_event_and_shift` pins it against ghostty's cases. The dead key I was worried about never arrives as a printable key event — it arrives here, as a preview. I have said so on the issue.