### PR TITLE
Cluster the composition preview like printed text

### DIFF
--- a/lib/embed/shitty_vt.h
+++ b/lib/embed/shitty_vt.h
@@ -405,6 +405,11 @@ extern "C" {
      * the input method hides its cursor. That range is shown in reverse
      * video, the rest of the preview underlined.
      *
+     * The preview clusters like printed text: a combining mark, a joiner
+     * or a variation selector shares the cell it extends, and the cell's
+     * grapheme carries the whole cluster. What the preview shows is what
+     * the grid will hold once the composition commits.
+     *
      * While a preview is up shitty_vt_cursor_state reports a hidden
      * cursor positioned at the preview's cursor cell, which is where an
      * input method wants its candidate window. */

--- a/lib/vterm/vterm.cpp
+++ b/lib/vterm/vterm.cpp
@@ -2627,10 +2627,33 @@ void VtermImpl::dropUriList(Input& source) {
     }
 }
 
+// A control or a joiner opening a cluster has no cell of its own and
+// nothing to extend, so printed text drops it - and so does the preview.
+// C1 codepoints are the exception, as they are in the grid: decoded out
+// of UTF-8 text they are placed like ordinary characters.
+static bool droppedAtClusterStart(u32 codepoint) {
+    if (codepoint >= 0x80 && codepoint <= 0x9f) {
+        return false;
+    }
+    const GraphemeClass graphemeClass = unicodeCodepointProperties(codepoint).graphemeClass;
+    return graphemeClass == GraphemeClass::Control || graphemeClass == GraphemeClass::Zwj;
+}
+
 void VtermImpl::preedit(StringView text, i32 cursorBegin, i32 cursorEnd) {
     preeditCells.clear();
     preeditCursorBeginCell = -1;
     preeditCursorEndCell = -1;
+
+    // The preview clusters like printed text: a combining mark, a joiner
+    // or a variation selector extends the cell before it instead of
+    // losing its codepoint, and a cluster that changes width takes its
+    // second cell with it. What the input method shows is then what the
+    // grid will hold once the composition commits.
+    CellExtraStore& extras = *extras_.store;
+    GraphemeBreaker breaker;
+    GraphemeBuffer cluster;
+    // The lead cell of the cluster still open; -1 when there is none.
+    i32 leadCell = -1;
 
     const u8* bytes = text.data();
     size_t remaining = text.length();
@@ -2644,8 +2667,34 @@ void VtermImpl::preedit(StringView text, i32 cursorBegin, i32 cursorEnd) {
         if (cursorBegin >= 0 && preeditCursorBeginCell < 0 && offset >= cursorBegin) {
             preeditCursorBeginCell = (i32)(preeditCells.length());
         }
-        const int width = config().widths.codepointWidth(codepoint);
-        if (width > 0) {
+        const u8 data = codepointData(codepoint);
+        const u8 width = data & 0x03;
+        const bool boundary = breaker.breakBefore(codepoint, (data & 0x04) != 0);
+        if (!boundary && leadCell >= 0) {
+            const u32 previous = cluster.data()[cluster.size() - 1];
+            const GraphemeWidthEffect widthEffect = graphemeClusterMode ? config().widths.graphemeWidthEffect(previous, codepoint) : GraphemeWidthEffect::Unchanged;
+            // Past the cluster limit the preview keeps what it has, as
+            // the grid does.
+            if (cluster.pushBack(codepoint)) {
+                if (widthEffect == GraphemeWidthEffect::Wide && !preeditCells[leadCell].dwidth) {
+                    preeditCells.mut(leadCell).dwidth = 1;
+                    TerminalCell continuation{};
+                    continuation.dwidth_cont = 1;
+                    continuation.drawn = 1;
+                    preeditCells.pushBack(continuation);
+                } else if (widthEffect == GraphemeWidthEffect::Narrow && preeditCells[leadCell].dwidth) {
+                    preeditCells.mut(leadCell).dwidth = 0;
+                    preeditCells.popBack();
+                }
+                extras.setGrapheme(preeditCells.mut(leadCell), cluster.data(), cluster.size());
+            }
+        } else if (width == 0 && droppedAtClusterStart(codepoint)) {
+            breaker.reset();
+            leadCell = -1;
+        } else {
+            leadCell = (i32)(preeditCells.length());
+            cluster.clear();
+            cluster.pushBack(codepoint);
             TerminalCell cell{};
             cell.uc_pt = codepoint;
             cell.drawn = 1;
@@ -3241,6 +3290,20 @@ void VtermImpl::collectCellExtras() {
     if (altScreenInitialized) {
         frame_alt->collectExtraCells(extraCells);
     }
+    // The composition preview and the slice the overlay points at live
+    // outside both frames, and their clusters reference the same store:
+    // a collection that skipped them would leave the preview pointing
+    // into the freed pool.
+    const auto collectPreeditCells = [&](Vector<TerminalCell>& cells) {
+        for (size_t index = 0; index != cells.length(); ++index) {
+            TerminalCell& cell = cells.mut(index);
+            if (cell.hasExtra()) {
+                extraCells.pushBack(&cell);
+            }
+        }
+    };
+    collectPreeditCells(preeditCells);
+    collectPreeditCells(preeditWindow);
 
     CellExtraStore& extras = *extras_.store;
     extras.collect(extraCells, roots, rootCount);

--- a/lib/vterm/vterm.h
+++ b/lib/vterm/vterm.h
@@ -209,7 +209,9 @@ struct Vterm {
     // cursor row of the emitted frame; never enters the screen model,
     // the scrollback, or the pty. Empty text clears the preview.
     // cursorBegin/cursorEnd are byte offsets into text, or -1 when the
-    // input method hides its cursor.
+    // input method hides its cursor. The preview clusters like printed
+    // text, so it shows what the grid will hold once the composition
+    // commits.
     virtual void preedit(stl::StringView text, i32 cursorBegin, i32 cursorEnd) = 0;
     // Text dropped onto the window by a drag-and-drop session; the stream
     // is pulled on the calling fiber chunk by chunk under the PTY mutex,

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -924,6 +924,32 @@ class PreeditTest(unittest.TestCase):
                 else:
                     self.assertEqual(result.preedit.text, text)
 
+    def test_a_combining_mark_shares_the_cell_it_extends(self):
+        # The preview clusters like printed text, and the facade hands
+        # the whole cluster over: one cell, both codepoints.
+        result = run_example(
+            b"hello", input_script=[preedit_command("e\u0301", 0, 3)]
+        )
+        self.assertEqual(
+            result.preedit,
+            Preedit(row=0, column=5, cells=1, text="e\u0301"),
+        )
+
+    def test_a_joined_emoji_is_one_preview_cluster(self):
+        result = run_example(
+            b"",
+            input_script=[preedit_command("\U0001f469\u200d\U0001f4bb", 0, 11)],
+        )
+        self.assertEqual(
+            result.preedit,
+            Preedit(
+                row=0,
+                column=0,
+                cells=1,
+                text="\U0001f469\u200d\U0001f4bb",
+            ),
+        )
+
 
 class DriverEdgeTest(unittest.TestCase):
     """Argument checks of the C API and the driver reached through the

--- a/tst/test_preedit.py
+++ b/tst/test_preedit.py
@@ -56,6 +56,93 @@ class PreeditTest(unittest.TestCase):
             snapshot = terminal.snapshot()
             self.assertEqual(snapshot.lines[0], "cdef")
 
+    def test_a_combining_mark_extends_the_preview_cell(self):
+        with Shitty(columns=10, rows=3) as terminal:
+            terminal.write(b"ab")
+            terminal.preedit("e\u0301", -1, -1)
+            snapshot = terminal.snapshot()
+            self.assertEqual(snapshot.lines[0][:4], "abe ")
+            state = terminal.render_state()
+            self.assertEqual(state.grapheme_cells, 1)
+            self.assertEqual(state.grapheme_codepoints, 2)
+
+    def test_a_variation_selector_widens_the_preview_cluster(self):
+        with Shitty(columns=10, rows=3) as terminal:
+            terminal.preedit("\u2764\ufe0f", -1, -1)
+            snapshot = terminal.snapshot()
+            self.assertTrue(snapshot.cell(0, 0).double_width)
+            self.assertTrue(snapshot.cell(1, 0).double_width_continuation)
+            self.assertEqual(terminal.render_state().grapheme_codepoints, 2)
+
+    def test_a_joined_emoji_keeps_one_preview_cluster(self):
+        with Shitty(columns=10, rows=3) as terminal:
+            terminal.preedit("\U0001f469\u200d\U0001f4bb", -1, -1)
+            snapshot = terminal.snapshot()
+            self.assertTrue(snapshot.cell(0, 0).double_width)
+            self.assertEqual(snapshot.cell(2, 0).char, " ")
+            self.assertEqual(terminal.render_state().grapheme_codepoints, 3)
+
+    def test_a_lone_joiner_leaves_no_preview(self):
+        with Shitty(columns=10, rows=3) as terminal:
+            terminal.write(b"ab")
+            terminal.preedit("\u200d", -1, -1)
+            snapshot = terminal.snapshot()
+            self.assertEqual(snapshot.lines[0][:3], "ab ")
+            self.assertEqual(snapshot.cursor_style, 1)
+
+    def test_the_cursor_anchor_counts_cluster_cells(self):
+        with Shitty(columns=10, rows=3) as terminal:
+            # Three bytes in: past "e" and its combining acute, which
+            # share one cell.
+            terminal.preedit("e\u0301x", 3, 3)
+            self.assertEqual(terminal.snapshot().cursor_x, 1)
+
+    def test_the_preview_clusters_like_printed_text(self):
+        def observe(terminal):
+            snapshot = terminal.snapshot()
+            state = terminal.render_state()
+            return (
+                snapshot.lines[0],
+                [
+                    (cell.char, cell.double_width, cell.double_width_continuation)
+                    for cell in snapshot.cells[: snapshot.columns]
+                ],
+                state.grapheme_cells,
+                state.grapheme_codepoints,
+            )
+
+        for text in (
+            "e\u0301",
+            "\u2764\ufe0f",
+            "\U0001f469\u200d\U0001f4bb",
+            "\u1100\u1161",
+            "ab\u0301",
+        ):
+            with self.subTest(text=text):
+                with Shitty(columns=10, rows=3) as terminal:
+                    terminal.preedit(text, -1, -1)
+                    preview = observe(terminal)
+                with Shitty(columns=10, rows=3) as terminal:
+                    terminal.write(text.encode())
+                    printed = observe(terminal)
+                self.assertEqual(preview, printed)
+
+    def test_a_preview_cluster_outlives_a_grapheme_collection(self):
+        # The preview references the shared extras store like any other
+        # cell: a collection that did not walk it would leave the cluster
+        # bound to whatever took the slot.
+        with Shitty(columns=10, rows=3, save_lines=0) as terminal:
+            terminal.preedit("e\u0301\u0302\u0303", -1, -1)
+            self.assertEqual(terminal.render_state().grapheme_codepoints, 4)
+            for _ in range(40):
+                terminal.write(b"\x1b[H" + "a\u0301b\u0301c\u0301d\u0301e\u0301".encode())
+                terminal.snapshot()
+            terminal.write(b"\x1b[2J\x1b[H")
+            terminal.snapshot()
+            state = terminal.render_state()
+            self.assertEqual(state.grapheme_cells, 1)
+            self.assertEqual(state.grapheme_codepoints, 4)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #109.

## The problem

`VtermImpl::preedit` walked the composition text codepoint by codepoint and
kept a cell only `if (width > 0)`. Every zero-width codepoint was discarded,
so the preview and the grid disagreed about the same text:

| text | preview before | grid |
|---|---|---|
| `e` + U+0301 | `e`, the mark gone | `é`, one cell, cluster of two |
| ❤ + U+FE0F | one column | two columns |
| 👩 ZWJ 💻 | two cells, four columns | one cell, two columns |
| U+1100 + U+1161 | `ᄀ`, the vowel gone | `가` |

The preview exists to show what will be committed, so this was visible as the
composition changing shape at the moment it landed in the grid.

## The change

The cell run now clusters exactly the way `placeGraphicChar` does: the same
`GraphemeBreaker` decides boundaries, the same `graphemeWidthEffect` decides
whether a cluster gains or loses its second cell, and a cluster of more than
one codepoint goes through `CellExtraStore::setGrapheme` as `writeGrapheme`
stores it. A control or a joiner that opens a cluster still gets no cell, as
in the grid. Nothing about clustering is re-decided here - only the cursor,
the margins and the wrap are absent, because a preview has none.

That gives preview cells refs into the shared extras store, which the
collection then has to walk. It walks the two screen frames, and the preview
belongs to neither, so `collectCellExtras` now walks `preeditCells` and the
`preeditWindow` slice the overlay points at alongside them. Without that the
preview keeps rendering after a collection but bound to whatever cluster took
its slot - `test_a_preview_cluster_outlives_a_grapheme_collection` fails
exactly that way if the two walks are removed (a four-codepoint preview comes
back reporting two).

`shitty_vt_preedit_cells` needed no change: `emitCell` already reads a cell's
grapheme out of the store, so the facade hands the whole cluster over.

## Tests

`tst/test_preedit.py` (+7): the mark that extends its cell, the variation
selector that widens the cluster, the joined emoji that stays one, the lone
joiner that leaves no preview, the cursor anchor counted in cells rather than
codepoints, the collection above, and a table-driven check that the preview
and printed text produce the same cells, widths and grapheme counters for the
same input.

`tst/test_embed_example.py` (+2): the same two clusters observed through the C
facade, where the reported cell text carries every codepoint.

`test_preedit` 13/13, `test_embed_example` 98/98, full `tst` suite 6541 tests
with no new failures (7 pre-existing environment failures - missing
`toml_dump`/`pt_test` version stamps and a COLRv1 emoji face - fail
identically on a clean tree).
