### PR TITLE
Report where a cell's color came from, not only what it resolved to

### DIFF
--- a/bin/example/main.c
+++ b/bin/example/main.c
@@ -106,6 +106,36 @@ static void collect_preview(void* user, uint16_t row, uint16_t column, const shi
     collect_cell(span->grid, 0, column, cell);
 }
 
+/* One color's provenance, as the header packs it. */
+static const char* color_source_name(uint16_t source, char* buffer, size_t size) {
+    switch (SHITTY_VT_COLOR_KIND(source)) {
+        case SHITTY_VT_COLOR_DEFAULT_FOREGROUND:
+            return "default_fg";
+        case SHITTY_VT_COLOR_DEFAULT_BACKGROUND:
+            return "default_bg";
+        case SHITTY_VT_COLOR_INDEXED:
+            snprintf(buffer, size, "indexed:%u", (unsigned)SHITTY_VT_COLOR_INDEX(source));
+            return buffer;
+        default:
+            return "direct";
+    }
+}
+
+/* Every drawn cell of the top row as column=fg/bg/underline. */
+static void collect_colors(void* user, uint16_t row, uint16_t column, const shitty_vt_cell* cell) {
+    char foreground[16];
+    char background[16];
+    char underline[16];
+    (void)user;
+    if (row != 0 || cell->grapheme_len == 0) {
+        return;
+    }
+    printf(" %u=%s/%s/%s", column,
+           color_source_name(cell->foreground_source, foreground, sizeof(foreground)),
+           color_source_name(cell->background_source, background, sizeof(background)),
+           color_source_name(cell->underline_source, underline, sizeof(underline)));
+}
+
 static void on_title(void* user, const uint8_t* title, size_t len) {
     (void)user;
     printf("title: %.*s\n", (int)len, (const char*)title);
@@ -318,6 +348,10 @@ int main(int argc, char** argv) {
         printf("cursor: %u %u style=%u visible=%u\n", cursor.column, cursor.row, cursor.style, cursor.visible);
     }
     printf("modes: 0x%x\n", shitty_vt_modes(vt));
+
+    fputs("colors:", stdout);
+    shitty_vt_each_cell(vt, collect_colors, NULL);
+    fputc('\n', stdout);
 
     {
         uint8_t replies[4096];

--- a/lib/embed/shitty_vt.cpp
+++ b/lib/embed/shitty_vt.cpp
@@ -468,6 +468,22 @@ namespace {
     // through rather than derived, so a caller reading the history by
     // index reports that index, and the preview reports where it is
     // drawn. The continuation of a wide cell is not reported.
+    // Where a color came from, in the shape the header documents: the
+    // kind in the low byte, the palette entry in the high one.
+    static u16 packColorSource(CellColor color) {
+        switch (color.source()) {
+            case CellColor::Source::DefaultForeground:
+                return SHITTY_VT_COLOR_DEFAULT_FOREGROUND;
+            case CellColor::Source::DefaultBackground:
+                return SHITTY_VT_COLOR_DEFAULT_BACKGROUND;
+            case CellColor::Source::Indexed:
+                return (u16)(SHITTY_VT_COLOR_INDEXED | (color.index() << 8));
+            case CellColor::Source::Direct:
+                return SHITTY_VT_COLOR_DIRECT;
+        }
+        return SHITTY_VT_COLOR_DIRECT;
+    }
+
     static void emitCell(shitty_vt* vt, const TerminalColors* colors, const TerminalCell& cell, u16 row, u16 column, shitty_vt_cell_fn fn, void* user) {
         if (cell.dwidth_cont) {
             return;
@@ -484,10 +500,25 @@ namespace {
             out.grapheme = &single;
             out.grapheme_len = 1;
         }
+        const CellColor foreground = cell.foreground();
+        const CellColor background = cell.background();
+        const CellColor underline = extras->underlineColor(cell);
+        out.foreground_source = packColorSource(foreground);
+        out.background_source = packColorSource(background);
+        out.underline_source = packColorSource(underline);
         if (colors != nullptr) {
             out.foreground = colors->resolveForeground(cell).packed();
             out.background = colors->resolveBackground(cell).packed();
-            out.underline_color = colors->resolve(extras->underlineColor(cell)).packed();
+            out.underline_color = colors->resolve(underline).packed();
+            // A configured special color stood in for the request. The
+            // embedder is handed a color, not a palette entry it could
+            // resolve for itself.
+            if (colors->resolve(foreground).packed() != out.foreground) {
+                out.foreground_source = SHITTY_VT_COLOR_DIRECT;
+            }
+            if (colors->resolve(background).packed() != out.background) {
+                out.background_source = SHITTY_VT_COLOR_DIRECT;
+            }
         }
         out.attributes = (u16)(packAttributes(cell));
         out.underline_style = (u8)(cell.underline_style);

--- a/lib/embed/shitty_vt.h
+++ b/lib/embed/shitty_vt.h
@@ -44,6 +44,16 @@
  * sent as arrow keys rather than scrolling a history it does not keep. */
 #define SHITTY_VT_MODE_ALTERNATE_SCROLL (1u << 15)
 
+/* Low byte of a shitty_vt_cell color source: where the color the
+ * application asked for came from, before the palette resolved it. */
+#define SHITTY_VT_COLOR_DEFAULT_FOREGROUND 0
+#define SHITTY_VT_COLOR_DEFAULT_BACKGROUND 1
+#define SHITTY_VT_COLOR_INDEXED 2
+#define SHITTY_VT_COLOR_DIRECT 3
+#define SHITTY_VT_COLOR_KIND(source) ((source) & 0xff)
+/* Palette entry, valid when the kind is SHITTY_VT_COLOR_INDEXED. */
+#define SHITTY_VT_COLOR_INDEX(source) (((source) >> 8) & 0xff)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,7 +63,27 @@ extern "C" {
      * 0x00BBGGRR - the little-endian view of struct { uint8_t r, g, b; }.
      * The grapheme is the cell's decoded codepoints; an empty cell has
      * grapheme_len 0. The pointer is valid only for the duration of the
-     * shitty_vt_each_cell callback. */
+     * shitty_vt_each_cell callback.
+     *
+     * The *_source fields say where each resolved color came from: the
+     * kind in the low byte, and for SHITTY_VT_COLOR_INDEXED the palette
+     * entry in the high byte. Read them with SHITTY_VT_COLOR_KIND and
+     * SHITTY_VT_COLOR_INDEX.
+     *
+     * An embedder that paints with this terminal's palette can ignore
+     * them and use the resolved values. One that owns a palette of its
+     * own - drawing into another terminal, or theming its panes - cannot:
+     * resolved RGB pins every cell to the colors this terminal was
+     * configured with, so an application asking for the default color, or
+     * for ANSI red, arrives painted rather than named and the embedder's
+     * own theme never applies. The source is what the application asked
+     * for; the resolved value is what this terminal would have drawn.
+     *
+     * A special color the terminal's own configuration sets - the bold,
+     * blink, underline, italic or inverse color - replaces the resolved
+     * value without replacing the request. Those cells report
+     * SHITTY_VT_COLOR_DIRECT, because what reaches the embedder is then a
+     * color in its own right rather than that palette entry. */
     typedef struct shitty_vt_cell {
         const uint32_t* grapheme;
         size_t grapheme_len;
@@ -65,6 +95,9 @@ extern "C" {
         uint8_t underline_style;
         /* 1 or 2; the continuation of a wide cell is not reported */
         uint8_t width;
+        uint16_t foreground_source;
+        uint16_t background_source;
+        uint16_t underline_source;
     } shitty_vt_cell;
 
     /* row is a row of the current view, not of the live screen: while the

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -44,6 +44,9 @@ class ExampleResult:
     capacity_rows: int
     cell_bytes: int
     preedit: "Preedit | None"
+    # column -> (foreground, background, underline) provenance of every
+    # drawn cell of the top row.
+    colors: dict
 
 
 @dataclass
@@ -105,12 +108,15 @@ def run_example(
     memory_line = lines.pop()
     scrollback_line = lines.pop()
     replies_line = lines.pop()
+    colors_line = lines.pop()
     modes_line = lines.pop()
     cursor_line = lines.pop()
     if not replies_line.startswith("replies:"):
         raise RuntimeError(f"unexpected replies line: {replies_line!r}")
     if not modes_line.startswith("modes: "):
         raise RuntimeError(f"unexpected modes line: {modes_line!r}")
+    if not colors_line.startswith("colors:"):
+        raise RuntimeError(f"unexpected colors line: {colors_line!r}")
     if not cursor_line.startswith("cursor: "):
         raise RuntimeError(f"unexpected cursor line: {cursor_line!r}")
     if not scrollback_line.startswith("scrollback: "):
@@ -128,6 +134,12 @@ def run_example(
     memory_fields = dict(
         field.split("=", 1) for field in memory_line[len("memory: ") :].split()
     )
+    colors = {
+        int(column): tuple(sources.split("/"))
+        for column, sources in (
+            field.split("=", 1) for field in colors_line[len("colors:") :].split()
+        )
+    }
     preedit = None
     if preedit_line != "preedit: none":
         head, text = preedit_line[len("preedit: ") :].split("text=", 1)
@@ -154,6 +166,7 @@ def run_example(
         capacity_rows=int(memory_fields["capacity_rows"]),
         cell_bytes=int(memory_fields["cell_bytes"]),
         preedit=preedit,
+        colors=colors,
     )
 
 
@@ -923,6 +936,56 @@ class PreeditTest(unittest.TestCase):
                     self.assertIsNone(result.preedit)
                 else:
                     self.assertEqual(result.preedit.text, text)
+
+
+class CellColorSourceTest(unittest.TestCase):
+    """Where each color came from, alongside what it resolved to.
+
+    An embedder with a palette of its own - drawing into another terminal,
+    or theming its panes - needs the request, not only the answer: resolved
+    RGB pins every cell to this terminal's configuration."""
+
+    def test_an_unstyled_cell_names_the_defaults(self):
+        result = run_example(b"hi")
+        self.assertEqual(result.colors[0], ("default_fg", "default_bg", "default_fg"))
+        self.assertEqual(result.colors[1], ("default_fg", "default_bg", "default_fg"))
+
+    def test_an_ansi_color_keeps_its_palette_index(self):
+        # Painted red is index 1 whatever this terminal resolves index 1
+        # to, which is what lets an embedder apply its own red.
+        result = run_example(b"\x1b[31mr\x1b[0m")
+        self.assertEqual(result.colors[0][0], "indexed:1")
+
+    def test_a_256_color_keeps_its_index_too(self):
+        result = run_example(b"\x1b[38;5;99mx\x1b[0m")
+        self.assertEqual(result.colors[0][0], "indexed:99")
+
+    def test_a_background_carries_its_own_source(self):
+        result = run_example(b"\x1b[44mb\x1b[0m")
+        self.assertEqual(result.colors[0][:2], ("default_fg", "indexed:4"))
+
+    def test_a_true_color_request_is_direct(self):
+        # Nothing to resolve: the application named the value itself.
+        result = run_example(b"\x1b[38;2;1;2;3mt\x1b[0m")
+        self.assertEqual(result.colors[0][0], "direct")
+
+    def test_the_underline_color_is_reported_separately(self):
+        result = run_example(b"\x1b[4;58;5;7mu\x1b[0m")
+        self.assertEqual(result.colors[0][2], "indexed:7")
+
+    def test_an_unset_underline_color_follows_the_foreground(self):
+        # The model has no separate default for it: an underline with no
+        # color of its own is drawn in the cell's foreground, and the
+        # source says so rather than inventing a default.
+        result = run_example(b"\x1b[4;31mu\x1b[0m")
+        self.assertEqual(result.colors[0][2], "indexed:1")
+
+    def test_a_redefined_palette_entry_is_still_that_entry(self):
+        # OSC 4 moves what index 1 resolves to. The cell still asked for
+        # index 1, which is the whole point of reporting the request: an
+        # embedder resolves it against its own palette, not this one.
+        result = run_example(b"\x1b]4;1;rgb:00/00/ff\x07\x1b[31mr\x1b[0m")
+        self.assertEqual(result.colors[0][0], "indexed:1")
 
 
 class DriverEdgeTest(unittest.TestCase):


### PR DESCRIPTION
## The problem

`shitty_vt_cell` reports colors resolved through this terminal's palette. For
an embedder that paints with this terminal's colors that is the whole answer.
For one that owns a palette of its own it is the wrong half of it.

I hit this building a second VT engine for [luvus](https://github.com/RizRiyz/luvus),
a multiplexer that draws its panes inside another terminal. Same input, same
pane, the two engines side by side, escapes captured from the host terminal:

| the application wrote | alacritty backend | shitty backend |
|---|---|---|
| plain text | `38;2;202;211;245` — the user's theme foreground | `38;2;255;255;255` |
| `ESC[31m` red | `38;5;1` — the host resolves its own red | `38;2;170;0;0` |

The other engine reports "default" and "index 1"; the host terminal then
applies the user's theme. Through the facade both arrive painted, so a pane
ignores the theme it sits in.

Neither case is recoverable downstream. I could guess the default by comparing
each resolved value against what the palette resolves an unstyled cell to —
which is what I shipped, and it is wrong for any cell painted in exactly that
color. Nothing recovers an index: it became three bytes before I saw it.

## The change

Three fields alongside the resolved values, not instead of them:

```c
uint16_t foreground_source;
uint16_t background_source;
uint16_t underline_source;
```

Kind in the low byte — `SHITTY_VT_COLOR_DEFAULT_FOREGROUND`,
`_DEFAULT_BACKGROUND`, `_INDEXED`, `_DIRECT`, matching `CellColor::Source` —
and for an indexed color the palette entry in the high byte.
`SHITTY_VT_COLOR_KIND` and `SHITTY_VT_COLOR_INDEX` read them.

Nothing about the resolved values changes: an embedder that wants the answer
keeps reading it, one that wants the question now can.

One case needed deciding. A special color the terminal's own configuration
substitutes — the bold, blink, underline, italic or inverse color — replaces
the resolved value without replacing the request. Those cells report `DIRECT`,
because what reaches the embedder is then a color in its own right; reporting
the index would hand back a number that does not describe what was given.

The underline color has no default of its own in the model — an underline
with no color set is drawn in the cell's foreground — so its source says so
rather than inventing one. That is pinned by a test.

## ABI

`shitty_vt_cell` grows by six bytes at the end. The header and the library
ship together through the tarball's `.pc`, so a consumer rebuilds; existing
call sites need no source change.

## Tests

`bin/example` prints the sources of the top row, and eight tests in
`tst/test_embed_example.py` cover the defaults, an ANSI index, a 256-color
index, a background, a true color, an underline color, the underline's
fallback to the foreground, and an index that survives `OSC 4` moving what it
resolves to — the case that shows why the request is worth reporting at all.

`test_embed_example` 104/104, full `tst` suite 6540 with no new failures
(7 pre-existing environment failures — missing `toml_dump`/`pt_test` version
stamps and a COLRv1 emoji face — fail identically on a clean tree),
`unit_tests` 646/646.
