### PR TITLE
Report where a row wrapped, so an embedder can rejoin the line

### DIFF
--- a/bin/example/main.c
+++ b/bin/example/main.c
@@ -221,6 +221,10 @@ static void run_input_line(shitty_vt* vt, const char* line) {
         shitty_vt_preedit(vt, bytes, used, begin, end);
     } else if (sscanf(line, "resize %u %u", &a, &b) == 2) {
         shitty_vt_resize(vt, (uint16_t)a, (uint16_t)b);
+    } else if (sscanf(line, "wrap %u", &a) == 1) {
+        /* Asks for one row by index, which the wrap line cannot do: it
+         * only walks the rows that exist. */
+        printf("wrap %u: %u\n", a, shitty_vt_row_wrap_length(vt, a));
     }
 }
 
@@ -365,6 +369,18 @@ int main(int argc, char** argv) {
     }
 
     printf("scrollback: offset=%u history=%u total=%u\n", shitty_vt_scroll_offset(vt), shitty_vt_history_rows(vt), shitty_vt_total_rows(vt));
+
+    {
+        /* Where every addressable row stops because it wrapped, history
+         * first, so a reader can rejoin the lines the terminal split. */
+        const uint32_t total = shitty_vt_total_rows(vt);
+        uint32_t index;
+        fputs("wrap:", stdout);
+        for (index = 0; index < total; ++index) {
+            printf(" %u=%u", index, shitty_vt_row_wrap_length(vt, index));
+        }
+        fputc('\n', stdout);
+    }
 
     {
         shitty_vt_memory memory;

--- a/lib/embed/shitty_vt.cpp
+++ b/lib/embed/shitty_vt.cpp
@@ -666,6 +666,35 @@ void shitty_vt_row_cells(shitty_vt* vt, uint32_t index, shitty_vt_cell_fn fn, vo
     vt->terminal->consume();
 }
 
+uint16_t shitty_vt_row_wrap_length(const shitty_vt* vt, uint32_t index) {
+    const TerminalUpdate* update = currentUpdate(const_cast<shitty_vt*>(vt));
+    if (update == nullptr || update->shapes == nullptr) {
+        return 0;
+    }
+    Screen* const screen = update->shapes;
+    const ScreenInfo info = screen->info();
+    if (index >= info.historyRows + info.rows) {
+        return 0;
+    }
+    // The same index arithmetic shitty_vt_row_cells does, so the two agree
+    // on which row an index names wherever the view happens to sit.
+    const i32 logical = (i32)(index) - (i32)(info.historyRows);
+    const i32 view = logical + (i32)(info.viewOffset);
+    const ScreenRowRef source = screen->viewRow(view);
+    if (source.cells == nullptr) {
+        return 0;
+    }
+    // The wrap bit marks the cell the row ran out of room at, so the text
+    // is everything up to and including it. Taking the first one set is
+    // what the model itself does when it measures a row this way.
+    for (u16 column = 0; column < info.columns; ++column) {
+        if (source.cells[column].wrap) {
+            return (u16)(column + 1);
+        }
+    }
+    return 0;
+}
+
 void shitty_vt_memory_usage(const shitty_vt* vt, shitty_vt_memory* out) {
     if (out == nullptr) {
         return;

--- a/lib/embed/shitty_vt.h
+++ b/lib/embed/shitty_vt.h
@@ -206,6 +206,24 @@ extern "C" {
      * the scrollback without scrolling; use shitty_vt_each_cell to read what
      * the user is looking at. */
     void shitty_vt_row_cells(shitty_vt*, uint32_t index, shitty_vt_cell_fn, void* user);
+
+    /* Where a row's text stops because it wrapped onto the next one: the
+     * columns that belong to the row, or 0 if it ends on its own. Indexed
+     * like shitty_vt_row_cells, and an index past the last row reports 0.
+     *
+     * An embedder that keeps its own scrollback needs this to tell one
+     * logical line from two. Without it a line the terminal wrapped comes
+     * back split at whatever width it happened to be written at, which is
+     * wrong for anything that reads the text again - a search, a copy, or
+     * handing a command's output to something else.
+     *
+     * It is a length rather than a flag because the terminal wraps
+     * wherever it ran out of room, which is not always the last column: a
+     * double-width character that does not fit leaves the one before it
+     * empty. Rejoining takes exactly this many columns and none of the
+     * blanks after them. Asking only whether the row continues is a
+     * comparison against 0. */
+    uint16_t shitty_vt_row_wrap_length(const shitty_vt*, uint32_t index);
     shitty_vt_cursor shitty_vt_cursor_state(const shitty_vt*);
     uint32_t shitty_vt_modes(const shitty_vt*);
 

--- a/tst/test_embed_example.py
+++ b/tst/test_embed_example.py
@@ -47,6 +47,9 @@ class ExampleResult:
     # column -> (foreground, background, underline) provenance of every
     # drawn cell of the top row.
     colors: dict
+    # absolute row index -> columns that belong to the row before it wrapped
+    # onto the next, 0 for a row that ends on its own.
+    wrap: dict
 
 
 @dataclass
@@ -106,6 +109,7 @@ def run_example(
         rows_by_index.insert(0, lines.pop())
     preedit_line = lines.pop()
     memory_line = lines.pop()
+    wrap_line = lines.pop()
     scrollback_line = lines.pop()
     replies_line = lines.pop()
     colors_line = lines.pop()
@@ -119,6 +123,8 @@ def run_example(
         raise RuntimeError(f"unexpected colors line: {colors_line!r}")
     if not cursor_line.startswith("cursor: "):
         raise RuntimeError(f"unexpected cursor line: {cursor_line!r}")
+    if not wrap_line.startswith("wrap:"):
+        raise RuntimeError(f"unexpected wrap line: {wrap_line!r}")
     if not scrollback_line.startswith("scrollback: "):
         raise RuntimeError(f"unexpected scrollback line: {scrollback_line!r}")
     if not memory_line.startswith("memory: "):
@@ -138,6 +144,12 @@ def run_example(
         int(column): tuple(sources.split("/"))
         for column, sources in (
             field.split("=", 1) for field in colors_line[len("colors:") :].split()
+        )
+    }
+    wrap = {
+        int(index): int(length)
+        for index, length in (
+            field.split("=", 1) for field in wrap_line[len("wrap:") :].split()
         )
     }
     preedit = None
@@ -167,6 +179,7 @@ def run_example(
         cell_bytes=int(memory_fields["cell_bytes"]),
         preedit=preedit,
         colors=colors,
+        wrap=wrap,
     )
 
 
@@ -1041,6 +1054,132 @@ class CellColorSourceTest(unittest.TestCase):
         )
         self.assertEqual(result.colors[0][1], "direct")
         self.assertEqual(result.colors[1][1], "default_bg")
+
+
+class RowWrapTest(unittest.TestCase):
+    """Where a row's text stops because it wrapped onto the next one.
+
+    An embedder rejoining a wrapped line needs more than "this row is
+    continued": the wrap point is wherever the terminal ran out of room,
+    which is not always the last column, and the columns after it belong
+    to no one.
+    """
+
+    def test_a_row_that_wraps_reports_where_it_stopped(self):
+        # Twelve characters into eight columns: the first row is full and
+        # continues, the second holds the rest and ends on its own.
+        result = run_example(b"abcdefghijkl", columns=8, rows=3)
+
+        self.assertEqual(result.wrap[0], 8)
+        self.assertEqual(result.wrap[1], 0)
+
+    def test_a_row_ended_by_a_newline_does_not_wrap(self):
+        result = run_example(b"abc\r\ndef", columns=8, rows=3)
+
+        self.assertEqual(result.wrap[0], 0)
+        self.assertEqual(result.wrap[1], 0)
+
+    def test_a_blank_row_does_not_wrap(self):
+        result = run_example(b"ab", columns=8, rows=3)
+
+        self.assertEqual(result.wrap[0], 0)
+        self.assertEqual(result.wrap[2], 0)
+
+    def test_a_wide_character_wraps_before_the_last_column(self):
+        # Seven narrow cells then a double-width one, which does not fit in
+        # the last column of eight. The row is continued and yet its text
+        # ends at column 7, so a flag saying only "wrapped" would leave an
+        # embedder rejoining a column of nothing.
+        result = run_example("abcdefg\u4e00".encode(), columns=8, rows=3)
+
+        self.assertEqual(result.wrap[0], 7)
+        self.assertEqual(result.lines[1][0], "\u4e00")
+
+    def test_autowrap_off_clamps_instead_of_wrapping(self):
+        # DECAWM off: the row keeps overwriting its last column rather than
+        # continuing, so nothing was wrapped.
+        result = run_example(b"\x1b[?7labcdefghijkl", columns=8, rows=3)
+
+        self.assertEqual(result.wrap[0], 0)
+
+    def test_a_scrolled_off_row_keeps_its_wrap(self):
+        # The index space is the one shitty_vt_row_cells uses - the retained
+        # history followed by the live grid - so a wrapped line that has
+        # scrolled out of view still reports where it wrapped.
+        result = run_example(
+            b"abcdefghijkl\r\n" + b"x\r\n" * 4,
+            columns=8,
+            rows=3,
+            save_lines=8,
+        )
+
+        self.assertGreater(result.history_rows, 0)
+        self.assertEqual(result.wrap[0], 8)
+        self.assertEqual(result.wrap[1], 0)
+
+    def test_the_wrap_survives_a_scrolled_view(self):
+        # Reading a row is independent of where the user has scrolled, and
+        # so is reading where it wrapped.
+        result = run_example(
+            b"abcdefghijkl\r\n" + b"x\r\n" * 4,
+            columns=8,
+            rows=3,
+            save_lines=8,
+            scroll=2,
+        )
+
+        self.assertEqual(result.scroll_offset, 2)
+        self.assertEqual(result.wrap[0], 8)
+
+    def test_an_index_past_the_last_row_reports_no_wrap(self):
+        # The header promises 0 rather than a guess, and an embedder
+        # walking a scrollback that shrank under it will ask.
+        result = run_example(
+            b"abcdefghijkl",
+            columns=8,
+            rows=3,
+            input_script=["wrap 2", "wrap 3", "wrap 99"],
+        )
+
+        self.assertEqual(result.events, ["wrap 2: 0", "wrap 3: 0", "wrap 99: 0"])
+
+    def test_the_wrap_follows_a_reflow(self):
+        # Resizing re-lays the text, so where a row wraps belongs to the
+        # screen it is on now rather than to the width it was written at.
+        written = b"abcdefghijkl"
+
+        # Narrower: one wrapped line becomes two, both continued.
+        narrowed = run_example(written, columns=8, rows=3, input_script=["resize 4 3"])
+        self.assertEqual([narrowed.wrap[index] for index in range(3)], [4, 4, 0])
+
+        # Wider: it fits, so nothing wraps.
+        widened = run_example(written, columns=8, rows=3, input_script=["resize 16 3"])
+        self.assertEqual(widened.wrap[0], 0)
+
+        # And back, which also shows the text survived the widening
+        # rather than the wrap having simply been cleared.
+        restored = run_example(
+            written,
+            columns=8,
+            rows=3,
+            dump_rows=1,
+            input_script=["resize 16 3", "resize 8 3"],
+        )
+        self.assertEqual(restored.wrap[0], 8)
+        self.assertEqual(restored.rows_by_index[:2], ["abcdefgh", "ijkl    "])
+
+    def test_every_addressable_row_reports_a_wrap(self):
+        # The index space is exactly the one shitty_vt_row_cells uses: the
+        # retained history first, then the live grid, one answer per row.
+        # An embedder walking its scrollback needs the two to line up.
+        result = run_example(
+            b"abcdefghijkl\r\n" + b"x\r\n" * 4,
+            columns=8,
+            rows=3,
+            save_lines=8,
+        )
+
+        self.assertEqual(sorted(result.wrap), list(range(result.total_rows)))
 
 
 class DriverEdgeTest(unittest.TestCase):


### PR DESCRIPTION
An embedder that keeps its own scrollback has to tell one logical line from two.
The model already knows which rows continue — a soft wrap sets the wrap bit on
the cell the row ran out of room at, and the selection code reads it that way
when it walks a wrapped-line chain — but nothing in the facade reported it. A
line the terminal wrapped came back split at whatever width it happened to be
written at, which is wrong for anything that reads the text again: a search, a
copy, or handing a command's output to something else.

```c
uint16_t shitty_vt_row_wrap_length(const shitty_vt*, uint32_t index);
```

The columns that belong to a row before it continued onto the next, and 0 for a
row that ends on its own. Indexed the way `shitty_vt_row_cells` is, so the two
agree on which row an index names wherever the view happens to sit.

### Why a length rather than a flag

The terminal wraps wherever it ran out of room, and that is not always the last
column: a double-width character that does not fit leaves the one before it
empty. Rejoining takes exactly this many columns and none of the blanks after
them. An embedder that only wants to know whether a row continues compares
against 0.

### Scope

The read borrows the render side's own window on the model — the same
`ScreenRowRef` that `emitRow` walks — so nothing in the VT core changes. The
diff is confined to `lib/embed/`, the example, and the tests.

Eight tests through the example, which now prints a `wrap:` line the way it
prints `colors:`: a row wrapped at the margin, one ended by a newline, a blank
one, a wide character that wraps a column early, DECAWM off clamping instead of
wrapping, a wrapped row that has scrolled into history, the same read while the
view is scrolled, and one answer per addressable row.

Locally: 6560 python tests and 646 unit tests, with two `test_font_fallback`
failures that predate this and come from a missing emoji font on the host.

### Why I wanted it

This is the last thing [Luvus](https://github.com/RizRiyz/luvus), a terminal
multiplexer, needed from the facade to run its panes on this VT core instead of
`alacritty_terminal` — and I can report that it now does: **luvus with the
embedded shitty terminal backend works locally**, driving real panes through
`shitty_vt` end to end. Its "capture recent output, unwrapped" mode was the one
feature still reading every physical row as its own logical line, and this
closes it.

Thank you for shitty, and for taking #111 and #112 so quickly — the colour
provenance in #112 is what made the panes inherit the host theme correctly, and
the extra `DIRECT` cases you added on top of it were a better read of the
special colours than mine.
