### PR TITLE
Make reading a cell cheaper for an embedder

### DIFF
--- a/lib/embed/shitty_vt.cpp
+++ b/lib/embed/shitty_vt.cpp
@@ -511,7 +511,12 @@ namespace {
         }
         const CellColor foreground = cell.foreground();
         const CellColor background = cell.background();
-        const CellColor underline = extras->underlineColor(cell);
+        // The store is reached through a virtual call that cannot inline, and
+        // a cell with no extra already carries its underline color inline.
+        // Taking that branch here rather than inside the store is worth about
+        // a tenth of what reading a cell costs, on a grid where almost no
+        // cell has an extra at all.
+        const CellColor underline = cell.hasExtra() ? extras->underlineColor(cell) : cell.inlineUnderlineColor();
         out.foreground_source = packColorSource(foreground);
         out.background_source = packColorSource(background);
         out.underline_source = packColorSource(underline);
@@ -522,11 +527,18 @@ namespace {
             // A configured special color stood in for the request. The
             // embedder is handed a color, not a palette entry it could
             // resolve for itself.
-            if (colors->resolve(foreground).packed() != out.foreground) {
-                out.foreground_source = SHITTY_VT_COLOR_DIRECT;
-            }
-            if (colors->resolve(background).packed() != out.background) {
-                out.background_source = SHITTY_VT_COLOR_DIRECT;
+            //
+            // Guarded, because detecting that substitution costs two more
+            // resolutions on every cell and nothing can substitute while no
+            // special color is enabled - which is every terminal that was
+            // never asked to use one.
+            if (colors->specialModes != 0) {
+                if (colors->resolve(foreground).packed() != out.foreground) {
+                    out.foreground_source = SHITTY_VT_COLOR_DIRECT;
+                }
+                if (colors->resolve(background).packed() != out.background) {
+                    out.background_source = SHITTY_VT_COLOR_DIRECT;
+                }
             }
         }
         out.attributes = (u16)(packAttributes(cell));


### PR DESCRIPTION
Reading the grid is the thing an embedder does most. A redraw walks every visible
cell; reading back a scrollback walks every retained one. Two things in that path
cost more than they need to, and both are in the facade rather than the core.

**The underline color went through the extra store for every cell.** The store is
reached through a virtual call that cannot inline, and its first act is to check
`hasExtra` and hand back the cell's inline color when there is no extra — which is
almost every cell on almost every grid. Taking that branch at the call site keeps
the common case out of the virtual call.

**The special-color check cost two extra resolutions per cell.** They exist to
notice when a configured bold, blink, underline, italic or inverse color stood in
for what the application asked for, which is what makes those cells report
`DIRECT`. Nothing can stand in while no special color is enabled, and
`specialModes` already says so in one byte, so the comparison now happens only on
a terminal that was asked to use one.

### Measurement

Four thousand rows of a hundred and twenty columns, walked two hundred times
through `shitty_vt_row_cells`, three runs each:

| | ms |
|---|---|
| master | 1540 / 1450 / 1454 |
| this change | 1231 / 1256 / 1231 |

About **15% off reading a cell**. Broken down by removing each piece in turn, the
color work was roughly 55% of the total: ~22% the underline store lookup, ~20% the
three primary resolutions, ~12% the special-color check.

### What I tried first, and dropped

I assumed the per-cell callback was the cost, and built a batched entry point that
filled a caller-provided array instead of calling back per cell. It measured
**0.98×** — within noise of the callback it replaced — so it is not in this PR.

Worth recording, because it is counter-intuitive: a C benchmark and a Rust
embedder both spend ~15ns per cell, and those figures agree to within 2%, so the
FFI boundary is not where the time goes either. The call is cheap; the color work
was not.

### Testing

The whole embed suite passes, including the special-color `DIRECT` tests that the
new guard could have broken had `specialModes` not been the right predicate. The
full test suite shows the same 16 failures before and after on this host — they
come from the recent placement change and from a missing emoji font here, not from
this.

Found while measuring [Luvus](https://github.com/RizRiyz/luvus) on this core
against `alacritty_terminal`, where the grid read was the one path that stayed
behind.
